### PR TITLE
Add some simple module-level testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 util/zenfs
 fs/*.o
+tests/results

--- a/tests/get_good_db_bench_params_for_zenfs.sh
+++ b/tests/get_good_db_bench_params_for_zenfs.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script intends to generate a good set of parameters for dbbench to use as a base for zenfs testing
+
+set -e
+
+DEV=$1
+CAP_SECTORS=$(blkzone report -c 5 /dev/$DEV | grep -oP '(?<=cap )[0-9xa-f]+' | head -1)
+ZONE_CAP=$(($CAP_SECTORS * 512))
+WB_SIZE=$(( 2 * 1024 * 1024 * 1024))
+echo "--target_file_size_base=$(($ZONE_CAP * 2 * 95 / 100)) --use_direct_io_for_flush_and_compaction --max_bytes_for_level_multiplier=4 --max_background_jobs=8 --use_direct_reads --write_buffer_size=$WB_SIZE"
+

--- a/tests/long_performance/0000_fillrandom.sh
+++ b/tests/long_performance/0000_fillrandom.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+source long_performance/common.sh
+
+DB_BENCH_PARAMS="--benchmarks=fillrandom --num=$NUM --value_size=$VALUE_SIZE --histogram $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
+
+echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" > $TEST_OUT
+$TOOLS_DIR/db_bench $DB_BENCH_PARAMS >> $TEST_OUT
+
+check_db_bench_workload_completion fillrandom
+exit $?

--- a/tests/long_performance/0001_overwrite.sh
+++ b/tests/long_performance/0001_overwrite.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+source long_performance/common.sh
+
+DB_BENCH_PARAMS="--benchmarks=overwrite --num=$NUM --value_size=$VALUE_SIZE --histogram --use_existing_db $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
+
+echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" > $TEST_OUT
+$TOOLS_DIR/db_bench $DB_BENCH_PARAMS >> $TEST_OUT
+
+check_db_bench_workload_completion overwrite
+exit $?

--- a/tests/long_performance/0002_readwhilewriting_ratelimit.sh
+++ b/tests/long_performance/0002_readwhilewriting_ratelimit.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+source long_performance/common.sh
+
+WRITE_RATE_LIMIT=$((1024 * 1024 * 10))
+DURATION=$((60 * 60))
+THREADS=32
+
+DB_BENCH_PARAMS="--benchmarks=readwhilewriting --num=$NUM --value_size=$VALUE_SIZE --threads=$THREADS --histogram --use_existing_db --duration=$DURATION --benchmark_write_rate_limit=$WRITE_RATE_LIMIT $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
+
+echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" > $TEST_OUT
+$TOOLS_DIR/db_bench $DB_BENCH_PARAMS >> $TEST_OUT
+
+check_db_bench_workload_completion readwhilewriting
+exit $?

--- a/tests/long_performance/common.sh
+++ b/tests/long_performance/common.sh
@@ -1,0 +1,18 @@
+# Exit on any error
+set -e
+
+# Common settings
+NUM=1000000000
+VALUE_SIZE=1000
+
+# Helper(s)
+
+check_db_bench_workload_completion() {
+  WORKLOAD=$1
+  if [ $(grep -wc -E "$WORKLOAD\s+:" $TEST_OUT) -ne 1 ]; then
+    echo "$(tput setaf 1)ERROR: the $WORKLOAD did not complete$(tput sgr 0)" 1>&2
+    return -1
+  fi
+  return 0
+}
+

--- a/tests/quick_performance/0000_fillseq.sh
+++ b/tests/quick_performance/0000_fillseq.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+WORKLOAD_SZ=10000000000
+
+echo "" > $TEST_OUT
+
+for VALUE_SIZE in 100 200 400 1000 2000 8000; do
+  NUM=$(( $WORKLOAD_SZ / $VALUE_SIZE ))
+  DB_BENCH_PARAMS="--benchmarks=fillseq --num=$NUM --value_size=$VALUE_SIZE --compression_type=none --histogram $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
+  echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" >> $TEST_OUT
+  $TOOLS_DIR/db_bench $DB_BENCH_PARAMS >> $TEST_OUT
+  RES=$?
+  if [ $RES -ne 0 ]; then
+    exit $RES
+  fi
+done
+
+exit 0

--- a/tests/quick_performance/0001_fillrandom.sh
+++ b/tests/quick_performance/0001_fillrandom.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+WORKLOAD_SZ=10000000000
+
+echo "" > $TEST_OUT
+
+for VALUE_SIZE in 100 200 400 1000 2000 8000; do
+  NUM=$(( $WORKLOAD_SZ / $VALUE_SIZE ))
+  DB_BENCH_PARAMS="--benchmarks=fillrandom --num=$NUM --value_size=$VALUE_SIZE --compression_type=none --histogram $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
+  echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" >> $TEST_OUT
+  $TOOLS_DIR/db_bench $DB_BENCH_PARAMS >> $TEST_OUT
+  RES=$?
+  if [ $RES -ne 0 ]; then
+    exit $RES
+  fi
+done
+
+exit 0

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+NAME=$1
+TEST_DIR=$2
+TESTS=$(ls $TEST_DIR/*_*.sh)
+
+OK_TESTS=0
+FAILED_TESTS=0
+
+export TOOLS_DIR="../../../"
+
+RESULT_PATH="results/$NAME"
+RESULT_DIR="results/$NAME/$TEST_DIR"
+
+mkdir -p $RESULT_DIR
+rm -rf "$RESULT_DIR/*"
+
+for TEST in $TESTS
+do
+  TESTCASE="$TEST"
+  echo "$(tput setaf 3)Running $TEST $(tput sgr 0)"
+  
+  export TEST_OUT="$RESULT_PATH/${TEST//sh/out}"
+  TEST_RES=$($TESTCASE)
+  RES=$?
+  echo ""
+  if [ $RES -eq 0 ]; then
+    echo "$(tput setaf 2)OK$(tput sgr 0)"
+    OK_TESTS=$((OK_TESTS+1))
+  else
+    echo "$(tput setaf 1)FAILED$(tput sgr 0)"
+    FAILED_TESTS=$((FAILED_TESTS+1))
+  fi
+done
+
+echo ""
+
+if [ $FAILED_TESTS -eq 0 ]; then
+  echo "$(tput setaf 2)ALL TESTS PASSED$(tput sgr 0)"
+else
+  echo "$(tput setaf 1)$FAILED_TESTS TESTS FAILED$(tput sgr 0)"
+fi
+
+echo "Test output avaiable at $RESULT_DIR"
+
+exit $FAILED_TESTS

--- a/tests/smoke/0000_fillseq.sh
+++ b/tests/smoke/0000_fillseq.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+source smoke/common.sh
+
+DB_BENCH_PARAMS="--benchmarks=fillseq --num=$NUM --value_size=$VALUE_SIZE --histogram $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
+
+echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" > $TEST_OUT
+$TOOLS_DIR/db_bench $DB_BENCH_PARAMS >> $TEST_OUT
+
+check_db_bench_workload_completion fillseq
+exit $?

--- a/tests/smoke/0001_fillrandom.sh
+++ b/tests/smoke/0001_fillrandom.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+source smoke/common.sh
+
+DB_BENCH_PARAMS="--benchmarks=fillrandom --num=$NUM --value_size=$VALUE_SIZE --histogram $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
+
+echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" > $TEST_OUT
+$TOOLS_DIR/db_bench $DB_BENCH_PARAMS >> $TEST_OUT
+
+check_db_bench_workload_completion fillrandom
+exit $?

--- a/tests/smoke/0002_overwrite.sh
+++ b/tests/smoke/0002_overwrite.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+source smoke/common.sh
+
+DB_BENCH_PARAMS="--benchmarks=overwrite --use_existing_db  --num=$NUM --value_size=$VALUE_SIZE --histogram $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
+
+echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" > $TEST_OUT
+$TOOLS_DIR/db_bench $DB_BENCH_PARAMS >> $TEST_OUT
+
+check_db_bench_workload_completion overwrite
+exit $?

--- a/tests/smoke/0003_readwhilewriting.sh
+++ b/tests/smoke/0003_readwhilewriting.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+source smoke/common.sh
+
+DURATION=10
+DB_BENCH_PARAMS="--benchmarks=readwhilewriting --use_existing_db --duration=$DURATION --num=$NUM --value_size=$VALUE_SIZE --histogram $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
+
+echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" > $TEST_OUT
+$TOOLS_DIR/db_bench $DB_BENCH_PARAMS >> $TEST_OUT
+
+check_db_bench_workload_completion readwhilewriting
+exit $?

--- a/tests/smoke/0004_dbstress.sh
+++ b/tests/smoke/0004_dbstress.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+source smoke/common.sh
+
+OPS_PER_THREAD=1000
+REOPENS=5
+
+DB_STRESS_PARAMS="--ops_per_thread=$OPS_PER_THREAD --reopen=$REOPENS $FS_PARAMS"
+
+echo "# Running db_stress with parameters: $DB_STRESS_PARAMS" > $TEST_OUT
+$TOOLS_DIR/db_stress $DB_STRESS_PARAMS >> $TEST_OUT
+
+if [ $(grep -wc "Verification successful" $TEST_OUT) -ne 1 ]; then
+  echo "$(tput setaf 1)ERROR: db stress did not complete successfully$(tput sgr 0)"
+  exit -1
+fi
+

--- a/tests/smoke/common.sh
+++ b/tests/smoke/common.sh
@@ -1,0 +1,18 @@
+# Exit on any error
+set -e
+
+# Common smoke test settings
+NUM=1000000
+VALUE_SIZE=800
+
+# Helper(s)
+
+check_db_bench_workload_completion() {
+  WORKLOAD=$1
+  if [ $(grep -wc -E "$WORKLOAD\s+:" $TEST_OUT) -ne 1 ]; then
+    echo "$(tput setaf 1)ERROR: the $WORKLOAD did not complete$(tput sgr 0)" 1>&2
+    return -1
+  fi
+  return 0
+}
+


### PR DESCRIPTION
    Add a simple testing framework inspired by xfstests / blktests and a test
    suite for minimal smoke testing running some db bench workloads and a short
    db_stress test.
    
    Tests can be run on normal filesystems and zenfs.
    A run script can runs a set of tests in a subdirectory.
    
    ./run.sh <name of test> <test subdirectory>
    
    Example command lines for the run.sh script:
    
      FS_PARAMS="--fs_uri=zenfs://dev:nvme3n1" ./run.sh zenfs_testrun smoke
      FS_PARAMS="--db=/mnt/xfs/test" ./run.sh xfs_testrun smoke
    
    Stdout results for each test is stored in results/<name of test>/<test suite>
    Comparing different runs enables checking performance regressions.

Also, Add two test sets for doing some basic performance testing and
a script that provides a decent base parameter set for testing zenfs
performance.

* The quick_performance test set tests raw zenfs performance with small
workloads.

* The long_performance set performs a longer test, requiring a disk
size of ~1T, stressing the io path and the allocation algorithm properly.

This is just a start, these test sets will be improved and added upon.

Performance regresions can be spotted by using e.g. vimdiff of the test output.

Example:

  cd plugin/zenfs/tests
  DB_BENCH_PARAMS=$(sudo ./get_good_db_bench_params_for_zenfs.sh nvme2n1)
  FS_PARAMS="--fs-uri=zenfs://dev:nvme2n1" DB_BENCH_EXTRA_PARAMS="$DB_BENCH_PARAMS" ./run.sh zenfs_testrun quick_performance/
