### PR TITLE
A slew of improvements and bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 util/zenfs
+fs/*.o

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -166,7 +166,7 @@ class ZenFS : public FileSystemWrapper {
                  std::shared_ptr<Logger> logger);
   virtual ~ZenFS();
 
-  Status Mount();
+  Status Mount(bool readonly);
   Status MkFS(std::string aux_fs_path, uint32_t finish_threshold);
   std::map<std::string, Env::WriteLifeTimeHint> GetWriteLifeTimeHints();
 

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -187,6 +187,15 @@ void ZoneFile::CloseWR() {
     active_zone_->CloseWR();
     active_zone_ = NULL;
   }
+  open_for_wr_ = false;
+}
+
+void ZoneFile::OpenWR() {
+    open_for_wr_ = true;
+}
+
+bool ZoneFile::IsOpenForWR() {
+    return open_for_wr_;
 }
 
 ZoneExtent* ZoneFile::GetExtent(uint64_t file_offset, uint64_t* dev_offset) {
@@ -369,6 +378,7 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
   }
 
   metadata_writer_ = metadata_writer;
+  zoneFile_->OpenWR();
 }
 
 ZonedWritableFile::~ZonedWritableFile() {

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -50,14 +50,17 @@ class ZoneFile {
   uint64_t file_id_;
 
   uint32_t nr_synced_extents_;
-
+  bool open_for_wr_ = false;
  public:
   explicit ZoneFile(ZonedBlockDevice* zbd, std::string filename,
                     uint64_t file_id_);
 
   virtual ~ZoneFile();
 
+  void OpenWR();
   void CloseWR();
+  bool IsOpenForWR();
+
   IOStatus Append(void* data, int data_size, int valid_size);
   IOStatus SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime);
   std::string GetFilename();

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -299,8 +299,24 @@ uint64_t ZonedBlockDevice::GetFreeSpace() {
   for (const auto z : io_zones) {
     free += z->capacity_;
   }
-
   return free;
+}
+
+uint64_t ZonedBlockDevice::GetUsedSpace() {
+  uint64_t used = 0;
+  for (const auto z : io_zones) {
+    used += z->used_capacity_;
+  }
+  return used;
+}
+
+uint64_t ZonedBlockDevice::GetReclaimableSpace() {
+  uint64_t reclaimable= 0;
+  for (const auto z : io_zones) {
+    if (z->IsFull())
+      reclaimable += (z->max_capacity_ - z->used_capacity_);
+  }
+  return reclaimable;
 }
 
 void ZonedBlockDevice::LogZoneStats() {

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -94,6 +94,9 @@ class ZonedBlockDevice {
   Zone *AllocateMetaZone();
 
   uint64_t GetFreeSpace();
+  uint64_t GetUsedSpace();
+  uint64_t GetReclaimableSpace();
+
   std::string GetFilename();
   uint32_t GetBlockSize();
 

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -113,6 +113,9 @@ class ZonedBlockDevice {
 
   void NotifyIOZoneFull();
   void NotifyIOZoneClosed();
+
+ private:
+  std::string ErrorToString(int err);
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
This pull requests adds a bunch of improvements and bug fixes, see commit messages below
```
commit 93b112c52c69ea0ccc715bc5cc76f5de3b1a6f17 
Author: Hans Holmberg <hans.holmberg@wdc.com>
Date:   Thu Mar 25 15:06:10 2021 +0000

    Dissallow deletes of files open for writing
    
    We don't support deleting files open for writing,
    so return an error if rocksdb tries to do this.
    
    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

commit 891a65339de4596f796e5745cc0b20b39f5b6ef5
Author: Hans Holmberg <hans.holmberg@wdc.com>
Date:   Thu Mar 18 12:34:44 2021 +0000

    Add object files to gitignore
    
    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

commit 094c270df993330b0b1a3b6e870a5859adcdd6c2
Author: Hans Holmberg <hans.holmberg@wdc.com>
Date:   Fri Mar 12 10:43:05 2021 +0000

    Enable read-only mounting
    
    Allow read-only mounts, so a live instance can be opened for
    checking disk space etc.
    
    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

commit acb7bf0e9f722b0f725194cdf6a41af5948d8de7
Author: Hans Holmberg <hans.holmberg@wdc.com>
Date:   Thu Mar 11 14:43:14 2021 +0000

    Add a new command: df command to the zenfs utility
    
    df shows the used and free capacity of the zenfs file system along
    with space amplification.
    
    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

commit 261bda1ba57db99bafef7d097b3d6883fee7cb7f
Author: Hans Holmberg <hans.holmberg@wdc.com>
Date:   Thu Mar 11 14:37:41 2021 +0000

    Make sure we have a single write-mount per file system
    
    Open the write FD with O_EXCL to make sure that there is a single
    write-access user of the file system.
    
    Also improve the error messages when opening the zoned block device.
    
    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>
```