### PR TITLE
Zenfs updates

### DIFF
--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -87,6 +87,7 @@ class ZonedBlockDevice {
   virtual ~ZonedBlockDevice();
 
   IOStatus Open(bool readonly = false);
+  IOStatus SetScheduler();
 
   Zone *GetIOZone(uint64_t offset);
 

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -112,12 +112,18 @@ void list_children(ZenFS *zenFS, std::string path) {
   IOOptions opts;
   IODebugContext dbg;
   std::vector<std::string> result;
+  uint64_t size;
   IOStatus io_status = zenFS->GetChildren(path, opts, &result, &dbg);
 
   if (!io_status.ok()) return;
 
   for (const auto f : result) {
-    fprintf(stdout, "%s\n", f.c_str());
+    io_status = zenFS->GetFileSize(path + "/" + f, opts, &size, &dbg);
+    if (!io_status.ok()) {
+      fprintf(stderr, "Failed to get size of file %s\n", f.c_str());
+      return;
+    }
+    fprintf(stdout, "%12lu\t%-32s\n", size, f.c_str());
   }
 }
 

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -99,6 +99,8 @@ int zenfs_tool_mkfs() {
     return 1;
   }
 
+  fprintf(stdout, "INFO: For ZBD %s, device scheduler is set to mq-deadline.\n",
+          FLAGS_zbd.c_str());
   fprintf(stdout, "ZenFS file system created. Free space: %lu MB\n",
           zbd->GetFreeSpace() / (1024 * 1024));
 


### PR DESCRIPTION
```
$ sudo ./zenfs mkfs --zbd=nvme0n1 --aux-path=/tmp/zenfs-aux --force
INFO: For ZBD /dev/nvme0n1, setting scheduler to mq-deadline.
ZenFS file system created. Free space: 3970899 MB
```



```
$ sudo ./zenfs list --zbd=nvme0n1 --path=rocksdbtest/dbbench
    67457871    000043.sst
    67456489    000080.sst
    67455822    000117.sst
    67457826    000154.sst
    67456048    000191.sst
    67455714    000228.sst
    67456436    000266.sst
    67455873    000294.sst
    67457790    000331.sst
    67455988    000368.sst
    67455714    000405.sst
    67456451    000442.sst
    67455755    000480.sst
    67457827    000518.sst
    67456007    000546.sst
    67455832    000583.sst
    67456482    000620.sst
    67455819    000657.sst
    67457813    000694.sst
    67456079    000732.sst
    67455727    000770.sst
    67456442    000808.sst

```