### PR TITLE
fs: persist a file record on file creation

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -466,6 +466,13 @@ IOStatus ZenFS::NewWritableFile(const std::string& fname,
 
   zoneFile = new ZoneFile(zbd_, fname, next_file_id_++);
 
+  /* Persist the creation of the file */
+  s = SyncFileMetadata(zoneFile);
+  if(!s.ok()) {
+    delete zoneFile;
+    return s;
+  }
+
   files_mtx_.lock();
   files_.insert(std::make_pair(fname.c_str(), zoneFile));
   files_mtx_.unlock();


### PR DESCRIPTION
We're not persisting file records until we get a sync or the
file is closed. This has been observed to cause problems
when recreating the file system state (delete records
of files that does not have an earlier file record in
the meta log)

The above issue has been seen during unclean shutdowns
of rocksdb(reboots, crashes).

Remove the possibility log inconsistency by persisting
a file record when a writable file is created - this
seems to be the right thing to do anyway.

Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>