### PR TITLE
Write buffer fixes

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -103,7 +103,7 @@ IOStatus ZenMetaLog::AddRecord(const Slice& slice) {
   assert(data != nullptr);
   assert((phys_sz % bs_) == 0);
 
-  ret = posix_memalign((void**)&buffer, bs_, phys_sz);
+  ret = posix_memalign((void**)&buffer, sysconf(_SC_PAGESIZE), phys_sz);
   if (ret) return IOStatus::IOError("Failed to allocate memory");
 
   memset(buffer, 0, phys_sz);

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -477,7 +477,7 @@ IOStatus ZenFS::NewWritableFile(const std::string& fname,
   files_.insert(std::make_pair(fname.c_str(), zoneFile));
   files_mtx_.unlock();
 
-  result->reset(new ZonedWritableFile(zbd_, true, zoneFile, &metadata_writer_));
+  result->reset(new ZonedWritableFile(zbd_, !file_opts.use_direct_writes, zoneFile, &metadata_writer_));
 
   return s;
 }

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -370,7 +370,7 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
   zoneFile_ = zoneFile;
 
   if (buffered) {
-    int ret = posix_memalign((void**)&buffer, block_sz, buffer_sz);
+    int ret = posix_memalign((void**)&buffer, sysconf(_SC_PAGESIZE), buffer_sz);
 
     if (ret) buffer = nullptr;
 
@@ -494,7 +494,7 @@ IOStatus ZonedWritableFile::BufferedWrite(const Slice& slice) {
     blocks = data_left / block_sz;
     aligned_sz = block_sz * blocks;
 
-    ret = posix_memalign(&alignbuf, block_sz, aligned_sz);
+    ret = posix_memalign(&alignbuf, sysconf(_SC_PAGESIZE), aligned_sz);
     if (ret) {
       return IOStatus::IOError("failed allocating alignment write buffer\n");
     }

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -212,7 +212,7 @@ IOStatus ZonedBlockDevice::Open(bool readonly) {
     return IOStatus::InvalidArgument("Failed to open zoned block device: " + ErrorToString(errno));
   }
 
-  read_direct_f_ = zbd_open(filename_.c_str(), O_RDONLY, &info);
+  read_direct_f_ = zbd_open(filename_.c_str(), O_RDONLY | O_DIRECT, &info);
   if (read_f_ < 0) {
     return IOStatus::InvalidArgument("Failed to open zoned block device: " + ErrorToString(errno));
   }


### PR DESCRIPTION
commit 548ca5dc65b9f6ca75fc8104518ad15325d1374c
Author: Hans Holmberg <hans.holmberg@wdc.com>
Date:   Thu Apr 29 08:52:19 2021 +0000

    fs: align buffers properly
    
    When submitting direct writes, the buffers should be
    page-size aligned, not block-size aligned. Fix this.
    
    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

commit e423a9355e0f5afea5726d3c71bf1f86e04546da
Author: Hans Holmberg <hans.holmberg@wdc.com>
Date:   Wed Apr 28 08:25:19 2021 +0000

    fs: enable direct writes
    
    For some reason, the direct(unbuffered) writes ended up being disabled
    in the initial commit of the project. Re-enable this, as it lowers
    cpu overhead and should have performance benifits when enabled.
    
    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>
