### PR TITLE
test: add zenfs utility related test cases to test suite.

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,19 +9,21 @@ OK_TESTS=0
 FAILED_TESTS=0
 
 export TOOLS_DIR="../../../"
+export ZENFS_DIR="../util/"
 
 RESULT_PATH="results/$NAME"
 RESULT_DIR="results/$NAME/$TEST_DIR"
 
 mkdir -p $RESULT_DIR
-rm -rf "$RESULT_DIR/*"
+rm -rf $RESULT_DIR/*
 
 for TEST in $TESTS
 do
   TESTCASE="$TEST"
   echo "$(tput setaf 3)Running $TEST $(tput sgr 0)"
   
-  export TEST_OUT="$RESULT_PATH/${TEST//sh/out}"
+  export RESULT_DIR="$RESULT_DIR"
+  export TEST_OUT="$RESULT_PATH/${TEST/sh/out}"
   TEST_RES=$($TESTCASE)
   RES=$?
   echo ""

--- a/tests/utils/0010_mkfs.sh
+++ b/tests/utils/0010_mkfs.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Format a ZBD and create a ZenFS filesystem
+
+rm -rf /tmp/zenfs-aux
+$ZENFS_DIR/zenfs mkfs --zbd=$ZDEV --aux-path=/tmp/zenfs-aux --force --finish-threshold=5 > $TEST_OUT
+RES=$?
+if [ $RES -ne 0 ]; then
+  exit $RES
+fi
+
+exit 0

--- a/tests/utils/0020_list.sh
+++ b/tests/utils/0020_list.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Run and verify db_bench write workload and list the files in the FS
+
+check_db_bench_workload_completion() {
+  WORKLOAD=$1
+  DBB_OUT=$2
+  if [ $(grep -wc -E "$WORKLOAD\s+:" $DBB_OUT) -ne 1 ]; then
+    echo "$(tput setaf 1)ERROR: the $WORKLOAD did not complete$(tput sgr 0)" 1>&2
+    return -1
+  fi
+  return 0
+}
+
+utest_run_fillrandom_dbbench_workload() {
+  DB_BENCH_PARAMS="--benchmarks=fillrandom --use_direct_io_for_flush_and_compaction --key_size=16 --value_size=800 --max_background_jobs=8 --num=1000000 --threads=2 --write_buffer_size=536870912 --target_file_size_base=1073741824 --target_file_size_multiplier=1 --max_bytes_for_level_multiplier=4 --histogram"
+  DBB_OUT=$1
+
+  $TOOLS_DIR/db_bench $DB_BENCH_PARAMS $FS_PARAMS > $DBB_OUT
+  check_db_bench_workload_completion fillrandom $DBB_OUT
+  return $?
+}
+
+DBB_LOG=$TEST_OUT-dbbench
+utest_run_fillrandom_dbbench_workload $DBB_LOG
+RES=$?
+if [ $RES -ne 0 ]; then
+  exit $RES
+fi
+
+$ZENFS_DIR/zenfs list --zbd=$ZDEV --path=rocksdbtest/dbbench > $TEST_OUT
+RES=$?
+if [ $RES -ne 0 ]; then
+  exit $RES
+fi
+
+FILES=$(cat $TEST_OUT | wc -l)
+if [ $FILES -lt 1 ]; then
+  echo "No files reported by list" >> $TEST_OUT
+  exit 1
+fi
+
+exit 0

--- a/tests/utils/0030_df.sh
+++ b/tests/utils/0030_df.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Verify zenfs df command works as expected, simple sanity check.
+
+$ZENFS_DIR/zenfs df --zbd=$ZDEV >> $TEST_OUT
+RES=$?
+if [ $RES -ne 0 ]; then
+  echo "Error: df failed to run" >> $TEST_OUT
+  exit $RES
+fi
+
+exit 0

--- a/tests/utils/0040_backup.sh
+++ b/tests/utils/0040_backup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# Do a zenfs backup and verify the backed up data and ondisk data match.
+
+source utils/common.sh
+
+BACKUP_DIR=$RESULT_DIR/backup
+
+LIST=$($ZENFS_DIR/zenfs list --zbd=$ZDEV --path=rocksdbtest/dbbench | wc -l)
+echo "List reported $LIST files, backup dir is $BACKUP_DIR"
+mkdir -p $BACKUP_DIR
+$ZENFS_DIR/zenfs backup --zbd=$ZDEV --path=$BACKUP_DIR >> $TEST_OUT
+RES=$?
+if [ $RES -ne 0 ]; then
+  echo "Backup failed"
+  exit $RES
+fi
+
+FILECOUNT=$(ls -1 $BACKUP_DIR/rocksdbtest/dbbench | wc -l)
+if [ $LIST -ne $FILECOUNT ]; then
+  echo "Files mismatch after backup" >> $TEST_OUT
+  exit 1
+fi
+
+utest_run_ldb_verify $BACKUP_DIR
+RES=$?
+if [ $RES -ne 0 ]; then
+  echo "Failed to verify backed up files" >> $TEST_OUT
+  exit $RES
+fi
+
+rm $RESULT_DIR/ondisk_db_dump
+rm $RESULT_DIR/backup_db_dump
+
+exit 0

--- a/tests/utils/0050_restore.sh
+++ b/tests/utils/0050_restore.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Do a zenfs restore and verify the restored data ondisk and source data match.
+
+source utils/common.sh
+
+BACKUP_DIR=$RESULT_DIR/backup
+
+cp $BACKUP_DIR/write_lifetime_hints.dat $BACKUP_DIR/rocksdbtest/dbbench/
+$ZENFS_DIR/zenfs restore --zbd=$ZDEV --path=$BACKUP_DIR/rocksdbtest/dbbench/ --restore-path=rocksdbtest/dbbench >> $TEST_OUT
+RES=$?
+if [ $RES -ne 0 ]; then
+  echo "Restore failed" >> $TEST_OUT
+  exit $RES
+fi
+
+utest_run_ldb_verify $BACKUP_DIR
+RES=$?
+if [ $RES -ne 0 ]; then
+  echo "Failed to verify restored up files" >> $TEST_OUT
+  exit $RES
+fi
+
+rm $RESULT_DIR/ondisk_db_dump
+rm $RESULT_DIR/backup_db_dump
+rm -rf $BACKUP_DIR/
+exit 0

--- a/tests/utils/common.sh
+++ b/tests/utils/common.sh
@@ -1,0 +1,17 @@
+# Exit on any error
+set -e
+# Helper(s)
+
+utest_run_ldb_verify() {
+  ONDISK_DB="--db=rocksdbtest/dbbench"
+  BACKUP_DB="--db=$1/rocksdbtest/dbbench"
+
+  echo "ONDISK_DB=$ONDISK_DB , BACKUP_DBPATH=$BACKUP_DB, LDB_PARAMS=$LDB_PARAMS" >> $RESULT_DIR/log
+  $TOOLS_DIR/ldb dump --hex $FS_PARAMS $ONDISK_DB > $RESULT_DIR/ondisk_db_dump
+
+  $TOOLS_DIR/ldb dump --hex $BACKUP_DB > $RESULT_DIR/backup_db_dump
+
+  diff $RESULT_DIR/ondisk_db_dump $RESULT_DIR/backup_db_dump
+
+  return $?
+}


### PR DESCRIPTION
Adds new tests to test zenfs mkfs, list, df, check scheduler,
backup, restore and post-restore data integrity check.

sudo FS_PARAMS="--fs-uri=zenfs://dev:nvme0n1" ./run.sh util-tests utils

Signed-off-by: Aravind Ramesh <Aravind.Ramesh@wdc.com>