### PR TITLE
Modification time

### DIFF
--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -216,6 +216,11 @@ class ZenFS : public FileSystemWrapper {
     return IOStatus::OK();
   }
 
+  IOStatus GetFileModificationTime(const std::string& fname,
+                                   const IOOptions& options,
+                                   uint64_t* mtime,
+                                   IODebugContext* dbg) override;
+
   // The directory structure is stored in the aux file system
 
   IOStatus IsDirectory(const std::string& path, const IOOptions& options,
@@ -314,14 +319,6 @@ class ZenFS : public FileSystemWrapper {
       std::unique_ptr<MemoryMappedFileBuffer>* /*result*/) override {
     return IOStatus::NotSupported(
         "MemoryMappedFileBuffer is not implemented in ZenFS");
-  }
-
-  IOStatus GetFileModificationTime(const std::string& /*fname*/,
-                                   const IOOptions& /*options*/,
-                                   uint64_t* /*file_mtime*/,
-                                   IODebugContext* /*dbg*/) override {
-    return IOStatus::NotSupported(
-        "GetFileModificationTime is not implemented in ZenFS");
   }
 
   virtual IOStatus LinkFile(const std::string& /*src*/,

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -51,6 +51,7 @@ class ZoneFile {
 
   uint32_t nr_synced_extents_;
   bool open_for_wr_ = false;
+  time_t m_time_;
  public:
   explicit ZoneFile(ZonedBlockDevice* zbd, std::string filename,
                     uint64_t file_id_);
@@ -65,6 +66,8 @@ class ZoneFile {
   IOStatus SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime);
   std::string GetFilename();
   void Rename(std::string name);
+  time_t GetFileModificationTime();
+  void SetFileModificationTime(time_t mt);
   uint64_t GetFileSize();
   void SetFileSize(uint64_t sz);
 

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -124,7 +124,21 @@ void list_children(ZenFS *zenFS, std::string path) {
       fprintf(stderr, "Failed to get size of file %s\n", f.c_str());
       return;
     }
-    fprintf(stdout, "%12lu\t%-32s\n", size, f.c_str());
+    uint64_t mtime;
+    io_status = zenFS->GetFileModificationTime(path + "/" + f, opts, &mtime, &dbg);
+    if (!io_status.ok()) {
+      fprintf(stderr, "Failed to get modification time of file %s, error = %s\n",
+                                             f.c_str(), io_status.ToString().c_str());
+      return;
+    }
+    time_t mt = (time_t)mtime;
+    struct tm* fct = std::localtime(&mt);
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%b %d %Y %H:%M:%S", fct);
+    std::string mdtime;
+    mdtime.assign(buf, sizeof(buf));
+
+    fprintf(stdout, "%12lu\t%-32s%-32s\n", size, mdtime.c_str(), f.c_str());
   }
 }
 


### PR DESCRIPTION
Add a modification time field to zonefiles.

```
$ sudo ./zenfs list --zbd=nvme0n1 --path=rocksdbtest/dbbench
       56158    Jun 02 2021 09:17:48            LOG
           0    Jun 02 2021 09:17:37            LOCK
   417960339    Jun 02 2021 09:17:42            000012.sst
   421439677    Jun 02 2021 09:17:45            000017.sst
   514117763    Jun 02 2021 09:17:46            000018.log
   242565614    Jun 02 2021 09:17:46            000019.sst
   267304814    Jun 02 2021 09:17:47            000021.log
          16    Jun 02 2021 09:17:37            CURRENT
          37    Jun 02 2021 09:17:37            IDENTITY
         917    Jun 02 2021 09:17:37            MANIFEST-000004
        6143    Jun 02 2021 09:17:37            OPTIONS-000007
```
