### PR TITLE
Fix gcc-11 and clang-12 compilation issues

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -971,7 +971,7 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold) {
   super->EncodeTo(&super_string);
 
   s = log->AddRecord(super_string);
-  if (!s.ok()) return s;
+  if (!s.ok()) return std::move(s);
 
   /* Write an empty snapshot to make the metadata zone valid */
   s = PersistSnapshot(log.get());

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -529,7 +529,7 @@ IOStatus ZenFS::GetChildren(const std::string& dir, const IOOptions& options,
   Debug(logger_, "GetChildren: %s \n", dir.c_str());
 
   target()->GetChildren(ToAuxPath(dir), options, &auxfiles, dbg);
-  for (const auto f : auxfiles) {
+  for (const auto& f : auxfiles) {
     if (f != "." && f != "..") result->push_back(f);
   }
 
@@ -859,7 +859,7 @@ Status ZenFS::Mount(bool readonly) {
      If that fails go to the previous as we might have crashed when rolling
      metadata zone.
   */
-  for (const auto sm : seq_map) {
+  for (const auto& sm : seq_map) {
     uint32_t i = sm.second;
     std::string scratch;
     std::unique_ptr<ZenMetaLog> log = std::move(valid_logs[i]);
@@ -900,7 +900,7 @@ Status ZenFS::Mount(bool readonly) {
   }
 
   /* Free up old metadata zones, to get ready to roll */
-  for (const auto sm : seq_map) {
+  for (const auto& sm : seq_map) {
     uint32_t i = sm.second;
     /* Don't reset the current metadata zone */
     if (i != r) {

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -327,13 +327,13 @@ class ZenFS : public FileSystemWrapper {
   virtual IOStatus LinkFile(const std::string& /*src*/,
                             const std::string& /*target*/,
                             const IOOptions& /*options*/,
-                            IODebugContext* /*dbg*/) {
+                            IODebugContext* /*dbg*/) override {
     return IOStatus::NotSupported("LinkFile is not supported in ZenFS");
   }
 
   virtual IOStatus NumFileLinks(const std::string& /*fname*/,
                                 const IOOptions& /*options*/,
-                                uint64_t* /*count*/, IODebugContext* /*dbg*/) {
+                                uint64_t* /*count*/, IODebugContext* /*dbg*/) override {
     return IOStatus::NotSupported(
         "Getting number of file links is not supported in ZenFS");
   }
@@ -341,7 +341,7 @@ class ZenFS : public FileSystemWrapper {
   virtual IOStatus AreFilesSame(const std::string& /*first*/,
                                 const std::string& /*second*/,
                                 const IOOptions& /*options*/, bool* /*res*/,
-                                IODebugContext* /*dbg*/) {
+                                IODebugContext* /*dbg*/) override {
     return IOStatus::NotSupported("AreFilesSame is not supported in ZenFS");
   }
 };

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -176,7 +176,7 @@ class ZonedSequentialFile : public FSSequentialFile {
   IOStatus PositionedRead(uint64_t offset, size_t n, const IOOptions& options,
                           Slice* result, char* scratch,
                           IODebugContext* dbg) override;
-  IOStatus Skip(uint64_t n);
+  IOStatus Skip(uint64_t n) override;
 
   bool use_direct_io() const override { return direct_; };
 

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -118,7 +118,7 @@ void list_children(ZenFS *zenFS, std::string path) {
 
   if (!io_status.ok()) return;
 
-  for (const auto f : result) {
+  for (const auto& f : result) {
     io_status = zenFS->GetFileSize(path + "/" + f, opts, &size, &dbg);
     if (!io_status.ok()) {
       fprintf(stderr, "Failed to get size of file %s\n", f.c_str());
@@ -284,7 +284,7 @@ IOStatus zenfs_tool_copy_dir(FileSystem *f_fs, std::string f_dir, FileSystem *t_
   s = f_fs->GetChildren(f_dir, opts, &files, &dbg);
   if (!s.ok()) { return s; }
   
-  for (const auto f : files) {
+  for (const auto& f : files) {
     std::string filename = f_dir + f;
     bool is_dir;
 


### PR DESCRIPTION
Fix the following gcc-11 compilation issues:
```
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.cc: In member function ‘virtual rocksdb::IOStatus rocksdb::ZenFS::GetChildren(const string&, const rocksdb::IOOptions&, std::vector<std::__cxx11::basic_string<char> >*, rocksdb::IODebugContext*)’:
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.cc:532:19: error: loop variable ‘f’ creates a copy from type ‘const std::__cxx11::basic_string<char>’ [-Werror=range-loop-construct]
  532 |   for (const auto f : auxfiles) {
      |                   ^
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.cc: In member function ‘rocksdb::Status rocksdb::ZenFS::Mount(bool)’:
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.cc:862:19: error: loop variable ‘sm’ creates a copy from type ‘const std::pair<unsigned int, unsigned int>’ [-Werror=range-loop-construct]
  862 |   for (const auto sm : seq_map) {
      |                   ^~
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.cc:903:19: error: loop variable ‘sm’ creates a copy from type ‘const std::pair<unsigned int, unsigned int>’ [-Werror=range-loop-construct]
  903 |   for (const auto sm : seq_map) {
      |                   ^~
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/util/zenfs.cc: In function ‘void rocksdb::list_children(rocksdb::ZenFS*, std::string)’:
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/util/zenfs.cc:121:19: error: loop variable ‘f’ creates a copy from type ‘const std::__cxx11::basic_string<char>’ [-Werror=range-loop-construct]
  121 |   for (const auto f : result) {
      |                   ^
```

Fix the following clang-12 compilation issues:
```
In file included from /data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/zbd_zenfs.cc:27:
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/io_zenfs.h:179:12: error: 'Skip' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  IOStatus Skip(uint64_t n);
           ^
In file included from /data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/util/zenfs.cc:16:
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.h:327:20: error: 'LinkFile' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  virtual IOStatus LinkFile(const std::string& /*src*/,
                   ^
In file included from /data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.cc:9:
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.h:334:20: error: 'NumFileLinks' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  virtual IOStatus NumFileLinks(const std::string& /*fname*/,
                   ^
In file included from /data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.cc:9:
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.h:341:20: error: 'AreFilesSame' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
  virtual IOStatus AreFilesSame(const std::string& /*first*/,
                   ^
/data/mysql-server/wdc-8.0/storage/rocksdb/rocksdb/plugin/zenfs/fs/fs_zenfs.cc:974:23: error: local variable 's' will be copied despite being returned by name [-Werror,-Wreturn-std-move]
  if (!s.ok()) return s;
                      ^
```