### PR TITLE
ci: add clang-format check

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -1,0 +1,19 @@
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+name: Lint
+jobs:
+  clang-format:
+    name: Lint with clang-format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v3.4.0
+      with:
+        clang-format-version: '11'
+        check-path: 'fs'

--- a/README.md
+++ b/README.md
@@ -107,5 +107,12 @@ Each valid meta data zone contains:
 * At least one snapshot of all files in the file system
 * Incremental file system updates (new files, new extents, deletes, renames etc)
 
-    
-    
+# Contribution Guide
+
+ZenFS uses clang-format with Google code style. You may run the following commands
+before submitting a PR.
+
+```bash
+clang-format-11 -n -Werror --style=file fs/* # Check for style issues
+clang-format-11 -i --style=file fs/*         # Auto-fix the style issues
+```

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -19,8 +19,8 @@
 #include <vector>
 
 #include "rocksdb/utilities/object_registry.h"
-#include "util/crc32c.h"
 #include "util/coding.h"
+#include "util/crc32c.h"
 
 #define DEFAULT_ZENV_LOG_PATH "/tmp/"
 
@@ -78,8 +78,7 @@ Status Superblock::CompatibleWith(ZonedBlockDevice* zbd) {
     return Status::Corruption("ZenFS Superblock",
                               "Error: block size missmatch");
   if (zone_size_ != (zbd->GetZoneSize() / block_size_))
-    return Status::Corruption("ZenFS Superblock",
-                              "Error: zone size missmatch");
+    return Status::Corruption("ZenFS Superblock", "Error: zone size missmatch");
   if (nr_zones_ > zbd->GetNrZones())
     return Status::Corruption("ZenFS Superblock",
                               "Error: nr of zones missmatch");
@@ -470,7 +469,7 @@ IOStatus ZenFS::NewWritableFile(const std::string& fname,
 
   /* Persist the creation of the file */
   s = SyncFileMetadata(zoneFile);
-  if(!s.ok()) {
+  if (!s.ok()) {
     delete zoneFile;
     return s;
   }
@@ -479,7 +478,8 @@ IOStatus ZenFS::NewWritableFile(const std::string& fname,
   files_.insert(std::make_pair(fname.c_str(), zoneFile));
   files_mtx_.unlock();
 
-  result->reset(new ZonedWritableFile(zbd_, !file_opts.use_direct_writes, zoneFile, &metadata_writer_));
+  result->reset(new ZonedWritableFile(zbd_, !file_opts.use_direct_writes,
+                                      zoneFile, &metadata_writer_));
 
   return s;
 }
@@ -558,7 +558,7 @@ IOStatus ZenFS::GetChildren(const std::string& dir, const IOOptions& options,
 IOStatus ZenFS::DeleteFile(const std::string& fname, const IOOptions& options,
                            IODebugContext* dbg) {
   IOStatus s;
-  ZoneFile *zoneFile = GetFile(fname);
+  ZoneFile* zoneFile = GetFile(fname);
 
   Debug(logger_, "Delete file: %s \n", fname.c_str());
 
@@ -579,19 +579,19 @@ IOStatus ZenFS::DeleteFile(const std::string& fname, const IOOptions& options,
 IOStatus ZenFS::GetFileModificationTime(const std::string& f,
                                         const IOOptions& options,
                                         uint64_t* mtime, IODebugContext* dbg) {
-   ZoneFile* zoneFile;
-   IOStatus s;
+  ZoneFile* zoneFile;
+  IOStatus s;
 
-   Debug(logger_, "GetFileModificationTime: %s \n", f.c_str());
-   files_mtx_.lock();
-   if (files_.find(f) != files_.end()) {
-     zoneFile = files_[f];
-     *mtime = (uint64_t)zoneFile->GetFileModificationTime();
-   } else {
-     s = target()->GetFileModificationTime(ToAuxPath(f), options, mtime, dbg);
-   }
-   files_mtx_.unlock();
-   return s;
+  Debug(logger_, "GetFileModificationTime: %s \n", f.c_str());
+  files_mtx_.lock();
+  if (files_.find(f) != files_.end()) {
+    zoneFile = files_[f];
+    *mtime = (uint64_t)zoneFile->GetFileModificationTime();
+  } else {
+    s = target()->GetFileModificationTime(ToAuxPath(f), options, mtime, dbg);
+  }
+  files_mtx_.unlock();
+  return s;
 }
 
 IOStatus ZenFS::GetFileSize(const std::string& f, const IOOptions& options,

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -7,10 +7,10 @@
 #pragma once
 
 #include "io_zenfs.h"
-#include "zbd_zenfs.h"
 #include "rocksdb/env.h"
 #include "rocksdb/file_system.h"
 #include "rocksdb/status.h"
+#include "zbd_zenfs.h"
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -217,8 +217,7 @@ class ZenFS : public FileSystemWrapper {
   }
 
   IOStatus GetFileModificationTime(const std::string& fname,
-                                   const IOOptions& options,
-                                   uint64_t* mtime,
+                                   const IOOptions& options, uint64_t* mtime,
                                    IODebugContext* dbg) override;
 
   // The directory structure is stored in the aux file system
@@ -330,7 +329,8 @@ class ZenFS : public FileSystemWrapper {
 
   virtual IOStatus NumFileLinks(const std::string& /*fname*/,
                                 const IOOptions& /*options*/,
-                                uint64_t* /*count*/, IODebugContext* /*dbg*/) override {
+                                uint64_t* /*count*/,
+                                IODebugContext* /*dbg*/) override {
     return IOStatus::NotSupported(
         "Getting number of file links is not supported in ZenFS");
   }

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -202,13 +202,9 @@ void ZoneFile::CloseWR() {
   open_for_wr_ = false;
 }
 
-void ZoneFile::OpenWR() {
-    open_for_wr_ = true;
-}
+void ZoneFile::OpenWR() { open_for_wr_ = true; }
 
-bool ZoneFile::IsOpenForWR() {
-    return open_for_wr_;
-}
+bool ZoneFile::IsOpenForWR() { return open_for_wr_; }
 
 ZoneExtent* ZoneFile::GetExtent(uint64_t file_offset, uint64_t* dev_offset) {
   for (unsigned int i = 0; i < extents_.size(); i++) {
@@ -262,8 +258,8 @@ IOStatus ZoneFile::PositionedRead(uint64_t offset, size_t n, Slice* result,
 
     if ((pread_sz + r_off) > extent_end) pread_sz = extent_end - r_off;
 
-    /* We may get some unaligned direct reads due to non-aligned extent lengths, so
-     * fall back on non-direct-io in that case.
+    /* We may get some unaligned direct reads due to non-aligned extent lengths,
+     * so fall back on non-direct-io in that case.
      */
     bool aligned = (pread_sz % zbd_->GetBlockSize() == 0);
     if (direct && aligned) {

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -52,6 +52,7 @@ class ZoneFile {
   uint32_t nr_synced_extents_;
   bool open_for_wr_ = false;
   time_t m_time_;
+
  public:
   explicit ZoneFile(ZonedBlockDevice* zbd, std::string filename,
                     uint64_t file_id_);

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -18,9 +18,9 @@
 #include <sys/ioctl.h>
 #include <unistd.h>
 
-#include <string>
-#include <sstream>
 #include <fstream>
+#include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -83,7 +83,8 @@ IOStatus Zone::Reset() {
   ret = zbd_reset_zones(zbd_->GetWriteFD(), start_, zone_sz);
   if (ret) return IOStatus::IOError("Zone reset failed\n");
 
-  ret = zbd_report_zones(zbd_->GetReadFD(), start_, zone_sz, ZBD_RO_ALL, &z, &report);
+  ret = zbd_report_zones(zbd_->GetReadFD(), start_, zone_sz, ZBD_RO_ALL, &z,
+                         &report);
 
   if (ret || (report != 1)) return IOStatus::IOError("Zone report failed\n");
 
@@ -168,11 +169,9 @@ ZonedBlockDevice::ZonedBlockDevice(std::string bdevname,
   Info(logger_, "New Zoned Block Device: %s", filename_.c_str());
 };
 
-
 std::string ZonedBlockDevice::ErrorToString(int err) {
   char *err_str = strerror(err);
-  if (err_str != nullptr)
-    return std::string(err_str);
+  if (err_str != nullptr) return std::string(err_str);
   return "";
 }
 
@@ -181,7 +180,7 @@ IOStatus ZonedBlockDevice::CheckScheduler() {
   std::string s = filename_;
   std::fstream f;
 
-  s.erase(0, 5); // Remove "/dev/" from /dev/nvmeXnY
+  s.erase(0, 5);  // Remove "/dev/" from /dev/nvmeXnY
   path << "/sys/block/" << s << "/queue/scheduler";
   f.open(path.str(), std::fstream::in);
   if (!f.is_open()) {
@@ -192,7 +191,8 @@ IOStatus ZonedBlockDevice::CheckScheduler() {
   getline(f, buf);
   if (buf.find("[mq-deadline]") == std::string::npos) {
     f.close();
-    return IOStatus::InvalidArgument("Current ZBD scheduler is not mq-deadline, set it to mq-deadline.");
+    return IOStatus::InvalidArgument(
+        "Current ZBD scheduler is not mq-deadline, set it to mq-deadline.");
   }
 
   f.close();
@@ -211,12 +211,14 @@ IOStatus ZonedBlockDevice::Open(bool readonly) {
 
   read_f_ = zbd_open(filename_.c_str(), O_RDONLY, &info);
   if (read_f_ < 0) {
-    return IOStatus::InvalidArgument("Failed to open zoned block device: " + ErrorToString(errno));
+    return IOStatus::InvalidArgument("Failed to open zoned block device: " +
+                                     ErrorToString(errno));
   }
 
   read_direct_f_ = zbd_open(filename_.c_str(), O_RDONLY | O_DIRECT, &info);
   if (read_direct_f_ < 0) {
-    return IOStatus::InvalidArgument("Failed to open zoned block device: " + ErrorToString(errno));
+    return IOStatus::InvalidArgument("Failed to open zoned block device: " +
+                                     ErrorToString(errno));
   }
 
   if (readonly) {
@@ -224,7 +226,8 @@ IOStatus ZonedBlockDevice::Open(bool readonly) {
   } else {
     write_f_ = zbd_open(filename_.c_str(), O_WRONLY | O_DIRECT | O_EXCL, &info);
     if (write_f_ < 0) {
-      return IOStatus::InvalidArgument("Failed to open zoned block device: " + ErrorToString(errno));
+      return IOStatus::InvalidArgument("Failed to open zoned block device: " +
+                                       ErrorToString(errno));
     }
   }
 
@@ -238,8 +241,7 @@ IOStatus ZonedBlockDevice::Open(bool readonly) {
   }
 
   IOStatus ios = CheckScheduler();
-  if (ios != IOStatus::OK())
-    return ios;
+  if (ios != IOStatus::OK()) return ios;
 
   block_sz_ = info.pblock_size;
   zone_sz_ = info.zone_size;
@@ -339,10 +341,9 @@ uint64_t ZonedBlockDevice::GetUsedSpace() {
 }
 
 uint64_t ZonedBlockDevice::GetReclaimableSpace() {
-  uint64_t reclaimable= 0;
+  uint64_t reclaimable = 0;
   for (const auto z : io_zones) {
-    if (z->IsFull())
-      reclaimable += (z->max_capacity_ - z->used_capacity_);
+    if (z->IsFull()) reclaimable += (z->max_capacity_ - z->used_capacity_);
   }
   return reclaimable;
 }


### PR DESCRIPTION
In this PR, we added clang-format lint for this repo. We use Google style, as it requires minimum effort for us to pass clang-format compared with other styles.