### PR TITLE
fs: only acquire lock once on deletion

### DIFF
--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -158,6 +158,7 @@ class ZenFS : public FileSystemWrapper {
     return path;
   }
 
+  ZoneFile* GetFileInternal(std::string fname);
   ZoneFile* GetFile(std::string fname);
   IOStatus DeleteFile(std::string fname);
 


### PR DESCRIPTION
If there are two threads concurrently calling DeleteFile, it seems possible that there will be a racing condition. This PR fixes this issue.

https://github.com/westerndigitalcorporation/zenfs/blob/master/fs/fs_zenfs.cc#L391

|             Thread 1                |           Thread 2            | |
| ----- | ---- | ---- |
| zoneFile = GetFile(fname); | zoneFile = GetFile(fname); | // both succeed |
|     files_mtx_.lock();           |     waiting                  | |
|   zoneFile = files_[fname]; |     waiting                  |  // succeed |
|    files_mtx_.unlock();        |    files_mtx_.lock();  | |
|                                              | if (zoneFile != nullptr) | // this check passes although zoneFile might have been deleted |
|                                              |   zoneFile = files_[fname]; | // fname is not in files_ any more, and zoneFile will become nullptr |

Point me out if I'm wrong, thanks!