### PR TITLE
util: enhance dump tool

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -668,7 +668,7 @@ void ZenFS::EncodeSnapshotTo(std::string* output) {
   PutLengthPrefixedSlice(output, Slice(files_string));
 }
 
-void ZenFS::EncodeJson(std::stringstream& json_stream) {
+void ZenFS::EncodeJson(std::ostream& json_stream) {
   bool first_element = true;
   json_stream << "[";
   for (const auto& file : files_) {

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -175,7 +175,7 @@ class ZenFS : public FileSystemWrapper {
     return "ZenFS - The Zoned-enabled File System";
   }
 
-  void EncodeJson(std::stringstream& json_stream);
+  void EncodeJson(std::ostream& json_stream);
 
   virtual IOStatus NewSequentialFile(const std::string& fname,
                                      const FileOptions& file_opts,

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -43,7 +43,7 @@ void ZoneExtent::EncodeTo(std::string* output) {
   PutFixed32(output, length_);
 }
 
-void ZoneExtent::EncodeJson(std::stringstream& json_stream) {
+void ZoneExtent::EncodeJson(std::ostream& json_stream) {
   json_stream << "{";
   json_stream << "\"start\":" << start_ << ",";
   json_stream << "\"length\":" << length_;
@@ -86,7 +86,7 @@ void ZoneFile::EncodeTo(std::string* output, uint32_t extent_start) {
    * as files will always be read-only after mount */
 }
 
-void ZoneFile::EncodeJson(std::stringstream& json_stream) {
+void ZoneFile::EncodeJson(std::ostream& json_stream) {
   json_stream << "{";
   json_stream << "\"id\":" << file_id_ << ",";
   json_stream << "\"filename\":\"" << filename_ << "\",";

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -35,7 +35,7 @@ class ZoneExtent {
   explicit ZoneExtent(uint64_t start, uint32_t length, Zone* zone);
   Status DecodeFrom(Slice* input);
   void EncodeTo(std::string* output);
-  void EncodeJson(std::stringstream& json_stream);
+  void EncodeJson(std::ostream& json_stream);
 };
 
 class ZoneFile {
@@ -88,7 +88,7 @@ class ZoneFile {
     EncodeTo(output, nr_synced_extents_);
   };
   void EncodeSnapshotTo(std::string* output) { EncodeTo(output, 0); };
-  void EncodeJson(std::stringstream& json_stream);
+  void EncodeJson(std::ostream& json_stream);
   void MetadataSynced() { nr_synced_extents_ = extents_.size(); };
 
   Status DecodeFrom(Slice* input);

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -72,7 +72,7 @@ void Zone::CloseWR() {
   if (capacity_ == 0) zbd_->NotifyIOZoneFull();
 }
 
-void Zone::EncodeJson(std::stringstream &json_stream) {
+void Zone::EncodeJson(std::ostream &json_stream) {
   json_stream << "{";
   json_stream << "\"start\":" << start_ << ",";
   json_stream << "\"capacity\":" << capacity_ << ",";
@@ -570,7 +570,7 @@ std::string ZonedBlockDevice::GetFilename() { return filename_; }
 
 uint32_t ZonedBlockDevice::GetBlockSize() { return block_sz_; }
 
-void ZonedBlockDevice::EncodeJsonZone(std::stringstream &json_stream,
+void ZonedBlockDevice::EncodeJsonZone(std::ostream &json_stream,
                                       const std::vector<Zone *> zones) {
   bool first_element = true;
   json_stream << "[";
@@ -586,7 +586,7 @@ void ZonedBlockDevice::EncodeJsonZone(std::stringstream &json_stream,
   json_stream << "]";
 }
 
-void ZonedBlockDevice::EncodeJson(std::stringstream &json_stream) {
+void ZonedBlockDevice::EncodeJson(std::ostream &json_stream) {
   json_stream << "{";
   json_stream << "\"meta\":";
   EncodeJsonZone(json_stream, meta_zones);

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -55,7 +55,7 @@ class Zone {
   uint64_t GetZoneNr();
   uint64_t GetCapacityLeft();
 
-  void EncodeJson(std::stringstream &json_stream);
+  void EncodeJson(std::ostream &json_stream);
 
   void CloseWR(); /* Done writing */
 };
@@ -84,7 +84,7 @@ class ZonedBlockDevice {
   unsigned int max_nr_active_io_zones_;
   unsigned int max_nr_open_io_zones_;
 
-  void EncodeJsonZone(std::stringstream &json_stream,
+  void EncodeJsonZone(std::ostream &json_stream,
                       const std::vector<Zone *> zones);
 
  public:
@@ -124,7 +124,7 @@ class ZonedBlockDevice {
   void NotifyIOZoneFull();
   void NotifyIOZoneClosed();
 
-  void EncodeJson(std::stringstream &json_stream);
+  void EncodeJson(std::ostream &json_stream);
 
  private:
   std::string ErrorToString(int err);

--- a/util/README.md
+++ b/util/README.md
@@ -33,7 +33,7 @@ Then, we could analyze the json file. Python 3.9+ is required, and we need to
 install some packages.
 
 ```bash
-pip3 install hurry.filesize -U
+pip3 install hurry.filesize cysimdjson cython tqdm -U
 ./zen-dump.py extents
 ```
 

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -410,13 +410,12 @@ int zenfs_tool_dump() {
     return 1;
   }
 
-  std::stringstream json_stream;
+  std::ostream &json_stream = std::cout;
   json_stream << "{\"zones\":";
   zbd->EncodeJson(json_stream);
   json_stream << ",\"files\":";
   zenFS->EncodeJson(json_stream);
   json_stream << "}";
-  fprintf(stdout, "%s\n", json_stream.str().c_str());
 
   return 0;
 }


### PR DESCRIPTION
This commit enhances the efficiency of dump tool. Now it could process several gigabytes of data within a minute. The JSON data is directly piped into stdout instead of being cached in a stringstream. And the analysis script is now using high-performance JSON parser while showing progress when processing data.

Signed-off-by: Alex Chi <iskyzh@gmail.com>