### PR TITLE
Allow zenfs backup to be run on an already mounted ZBDs

### DIFF
--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -357,10 +357,10 @@ int zenfs_tool_backup() {
   ZonedBlockDevice *zbd;
   ZenFS *zenFS;
 
-  zbd = zbd_open(false);
+  zbd = zbd_open(true);
   if (zbd == nullptr) return 1;
 
-  status = zenfs_mount(zbd, &zenFS, false);
+  status = zenfs_mount(zbd, &zenFS, true);
   if (!status.ok()) {
     fprintf(stderr, "Failed to mount filesystem, error: %s\n",
             status.ToString().c_str());


### PR DESCRIPTION
There is no need for 'zenfs' utility to require exclusive access to the drive
when performing backups. Therefore, in the 'backup' command handler 'zbd' is now opened
and 'zenfs' is now mounted in read-only mode.
Please note, that files still being written may be backed up only partially, so it
remains user's responsibility to ensure that the operation they are performing is
safe.