### PR TITLE
RFC zenfs: do reset and finish operations in a background thread

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -212,6 +212,7 @@ ZenFS::~ZenFS() {
   Status s;
   Info(logger_, "ZenFS shutting down");
   zbd_->LogZoneUsage();
+  zbd_->ShutdownZBDThread();
   LogFiles();
 
   meta_log_.reset(nullptr);
@@ -976,6 +977,7 @@ Status ZenFS::Mount(bool readonly) {
     Info(logger_, "Resetting unused IO Zones..");
     zbd_->ResetUnusedIOZones();
     Info(logger_, "  Done");
+    zbd_->CreateZBDThread();
   }
 
   LogFiles();


### PR DESCRIPTION
Due to the nature of finish and reset operations, applications can
experience large latencies when allocating zones to write.
To reduce it, move these operations to a background thread, which
runs whenever a active zone threshold is reached and does the reset
and finish operations in the background.

The allocation logic is same as before and remains as a part of AllocateZone(),
however, it notifies a condition variable on every successful allocation
of an empty zone. The logic to select a zone to reset/finish also remains same,
this patch splits the logic and moves the reset/finish part to a background thread.

Signed-off-by: Aravind Ramesh <Aravind.Ramesh@wdc.com>