### PR TITLE
[WIP] Add `GetZonedBlockDevice` API for fs_zenfs.h

### DIFF
--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -362,6 +362,8 @@ class ZenFS : public FileSystemWrapper {
                                 IODebugContext* /*dbg*/) {
     return IOStatus::NotSupported("AreFilesSame is not supported in ZenFS");
   }
+
+  ZonedBlockDevice* GetZonedBlockDevice() { return zbd_; }
 };
 #endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX)
 


### PR DESCRIPTION
Some applications may need to know more details about the devices, e.g. get devices zone stats, file counts etc.

Signed-off-by: Changlong Chen  <levisonchen@live.cn>