### PR TITLE
fs: a hotfix for slow WAL allocation, disassamble the lock inside All…

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -471,7 +471,7 @@ IOStatus ZenFS::NewWritableFile(const std::string& fname,
     if (!s.ok()) return s;
   }
 
-  zoneFile = new ZoneFile(zbd_, fname, next_file_id_++);
+  zoneFile = new ZoneFile(zbd_, fname, next_file_id_++, logger_);
   zoneFile->SetFileModificationTime(time(0));
 
   /* Persist the creation of the file */
@@ -687,7 +687,7 @@ void ZenFS::EncodeJson(std::ostream& json_stream) {
 }
 
 Status ZenFS::DecodeFileUpdateFrom(Slice* slice) {
-  ZoneFile* update = new ZoneFile(zbd_, "not_set", 0);
+  ZoneFile* update = new ZoneFile(zbd_, "not_set", 0, logger_);
   uint64_t id;
   Status s;
 
@@ -730,7 +730,7 @@ Status ZenFS::DecodeSnapshotFrom(Slice* input) {
   assert(files_.size() == 0);
 
   while (GetLengthPrefixedSlice(input, &slice)) {
-    ZoneFile* zoneFile = new ZoneFile(zbd_, "not_set", 0);
+    ZoneFile* zoneFile = new ZoneFile(zbd_, "not_set", 0, logger_);
     Status s = zoneFile->DecodeFrom(&slice);
     if (!s.ok()) return s;
 

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -189,8 +189,13 @@ Status ZoneFile::MergeUpdate(ZoneFile* update) {
   return Status::OK();
 }
 
+inline bool ends_with(std::string const& value, std::string const& ending) {
+  if (ending.size() > value.size()) return false;
+  return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+}
+
 ZoneFile::ZoneFile(ZonedBlockDevice* zbd, std::string filename,
-                   uint64_t file_id)
+                   uint64_t file_id, std::shared_ptr<Logger> logger)
     : zbd_(zbd),
       active_zone_(NULL),
       extent_start_(0),
@@ -200,7 +205,17 @@ ZoneFile::ZoneFile(ZonedBlockDevice* zbd, std::string filename,
       filename_(filename),
       file_id_(file_id),
       nr_synced_extents_(0),
-      m_time_(0) {}
+      m_time_(0),
+      logger_(logger),
+      is_wal_(false) {
+  // Generally, we should let our user to decide whether a file is WAL
+  // or not. However, current TerarkDB environment doesn't provide such
+  // capability to hint. Therefore, we simply check the suffix of filename
+  // here.
+  if (ends_with(filename_, ".log")) {
+    is_wal_ = true;
+  }
+}
 
 std::string ZoneFile::GetFilename() { return filename_; }
 void ZoneFile::Rename(std::string name) { filename_ = name; }
@@ -354,8 +369,9 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
   IOStatus s;
 
   if (active_zone_ == NULL) {
-    active_zone_ = zbd_->AllocateZone(lifetime_);
+    active_zone_ = zbd_->AllocateZone(lifetime_, is_wal_);
     if (!active_zone_) {
+      Warn(logger_, "Zone allocation failure upon append starting, filename=%s, lifetime=%d\n", filename_.c_str(), lifetime_);
       return IOStatus::NoSpace("Zone allocation failure\n");
     }
     extent_start_ = active_zone_->wp_;
@@ -367,8 +383,9 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
       PushExtent();
 
       active_zone_->CloseWR();
-      active_zone_ = zbd_->AllocateZone(lifetime_);
+      active_zone_ = zbd_->AllocateZone(lifetime_, is_wal_);
       if (!active_zone_) {
+        Warn(logger_, "Zone allocation failure when appending, filename=%s, left=%d\n", filename_.c_str(), left);
         return IOStatus::NoSpace("Zone allocation failure\n");
       }
       extent_start_ = active_zone_->wp_;

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -54,10 +54,13 @@ class ZoneFile {
   uint32_t nr_synced_extents_;
   bool open_for_wr_ = false;
   time_t m_time_;
+ 
+  std::shared_ptr<Logger> logger_;
+  bool is_wal_;
 
  public:
   explicit ZoneFile(ZonedBlockDevice* zbd, std::string filename,
-                    uint64_t file_id_);
+                    uint64_t file_id_, std::shared_ptr<Logger> logger);
 
   virtual ~ZoneFile();
 

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -68,6 +68,7 @@ class ZonedBlockDevice {
   uint32_t nr_zones_;
   std::vector<Zone *> io_zones;
   std::mutex io_zones_mtx;
+  std::mutex wal_zones_mtx;
   std::vector<Zone *> meta_zones;
   int read_f_;
   int read_direct_f_;
@@ -76,16 +77,22 @@ class ZonedBlockDevice {
   std::shared_ptr<Logger> logger_;
   uint32_t finish_threshold_ = 0;
 
+  // If a thread is allocating a zone fro WAL files, other
+  // thread shouldn't take `io_zones_mtx` (see AllocateZone())
+  std::atomic<uint32_t> wal_zone_allocating_{0};
+
   std::atomic<long> active_io_zones_;
   std::atomic<long> open_io_zones_;
   std::condition_variable zone_resources_;
-  std::mutex zone_resources_mtx_; /* Protects active/open io zones */
 
   unsigned int max_nr_active_io_zones_;
   unsigned int max_nr_open_io_zones_;
 
   void EncodeJsonZone(std::ostream &json_stream,
                       const std::vector<Zone *> zones);
+
+ public:
+  std::mutex zone_resources_mtx_; /* Protects active/open io zones */
 
  public:
   explicit ZonedBlockDevice(std::string bdevname,
@@ -97,7 +104,7 @@ class ZonedBlockDevice {
 
   Zone *GetIOZone(uint64_t offset);
 
-  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime);
+  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime, bool is_wal);
   Zone *AllocateMetaZone();
 
   uint64_t GetFreeSpace();


### PR DESCRIPTION
fs: a hotfix for slow WAL allocation, disassemble the lock inside AllocateZone()

- Separete WAL files and SST files
- For WAL files, we use `wal_zones_mtx` but for SST files we need both `wal_zones_mtx` and `io_zones_mtx`
- During the SST allocation, it can yield out CPU to let WAL allocation faster than before


Note that this is a temporary hotfix, we still need to refactor the AllocationZone() mechanism later.



Signed-off-by: Kuankuan Guo <guokuankuan@bytedance.com>

Signed-off-by: Alex Chi iskyzh@gmail.com