### PR TITLE
fs: refine zone close to prevent potential data racing

### DIFF
--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -63,9 +63,9 @@ uint64_t Zone::GetZoneNr() { return start_ / zbd_->GetZoneSize(); }
 
 void Zone::CloseWR() {
   assert(open_for_write_);
-  open_for_write_ = false;
 
   if (Close().ok()) {
+    assert(!open_for_write_);
     zbd_->NotifyIOZoneClosed();
   }
 
@@ -138,6 +138,7 @@ IOStatus Zone::Close() {
     if (ret) return IOStatus::IOError("Zone close failed\n");
   }
 
+  open_for_write_ = false;
   return IOStatus::OK();
 }
 


### PR DESCRIPTION
In `void Zone::CloseWR()`, the `open_for_write_` flag is re-assigned to `false` before it actually finished `Close()`, for the current version this is OK but if we optimize the `AllocateZone` in the future, it will have potential data racing problem.

Signed-off-by: Kuankuan Guo <guokuankuan@bytedance.com>