### PR TITLE
Improve ZonedWritableFile

### DIFF
--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -160,6 +160,7 @@ class ZonedWritableFile : public FSWritableFile {
   uint32_t block_sz;
   uint32_t buffer_pos;
   uint64_t wp;
+  uint64_t wp_synced;
   int write_temp;
 
   ZoneFile* zoneFile_;


### PR DESCRIPTION
This patch has follwing changes in `ZonedWritableFile`

`Fsync` is called twice when flush/compaction job finishes sstable, one from sync and the other from close even though there is no file data change between sync and close. I've changed `Fsync` to check last synced position before performing sync.

`PositionedAppend` may not work with buffered option, since `wp` is increased only when buffer is flushed. Although RocksDB does not seems to use `PositionedAppend` in non-direct mode. I changed `wp` to increase when data is appended to buffer.