### PR TITLE
util: allow backups of already mounted filesystems for testing purposes

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1069,7 +1069,7 @@ Status NewZenFS(FileSystem** fs, const std::string& bdevname) {
 #endif
 
   ZonedBlockDevice* zbd = new ZonedBlockDevice(bdevname, logger);
-  IOStatus zbd_status = zbd->Open();
+  IOStatus zbd_status = zbd->Open(false, true);
   if (!zbd_status.ok()) {
     Error(logger, "Failed to open zoned block device: %s",
           zbd_status.ToString().c_str());
@@ -1096,7 +1096,7 @@ std::map<std::string, std::string> ListZenFileSystems() {
     if (entry->d_type == DT_LNK) {
       std::string zbdName = std::string(entry->d_name);
       ZonedBlockDevice* zbd = new ZonedBlockDevice(zbdName, nullptr);
-      IOStatus zbd_status = zbd->Open(true);
+      IOStatus zbd_status = zbd->Open(true, false);
 
       if (zbd_status.ok()) {
         std::vector<Zone*> metazones = zbd->GetMetaZones();

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -92,7 +92,7 @@ class ZonedBlockDevice {
                             std::shared_ptr<Logger> logger);
   virtual ~ZonedBlockDevice();
 
-  IOStatus Open(bool readonly = false);
+  IOStatus Open(bool readonly, bool exclusive);
   IOStatus CheckScheduler();
 
   Zone *GetIOZone(uint64_t offset);


### PR DESCRIPTION
Allow for backing up mounted file systems with a live writer
for testing purposes.

We need some form of snapshots to do this without
risking data corruption/loss, but this is good enough
for now to get zenfs compatible with the mysql/myrocks
mtr tests.

Do this by allowing for non-exclusive block device
access when running the backup command with the --force flag.
A warning is emitted and the the potential data corruption
is documented in the help.

Suggested by Yura Sorokin (in #37 )

Example: (with an active mount by db bench doing writes in another process)
```
$./zenfs backup --zbd=nvme2n1 --path=/tmp/backup_test
Failed to open zoned block device: nvme2n1, error: Invalid argument: Failed to open zoned block device: Device or resource busy
$./zenfs backup --zbd=nvme2n1 --path=/tmp/backup_test --force
Failed to open zoned block device: nvme2n1, error: Invalid argument: Failed to open zoned block device: Device or resource busy
WARNING: attempting to back up a zoned block device in use! Expect data loss and corruption.
rocksdbtest/dbbench/LOG
rocksdbtest/dbbench/LOCK
rocksdbtest/dbbench/000014.log
rocksdbtest/dbbench/000016.sst
rocksdbtest/dbbench/000017.sst
rocksdbtest/dbbench/000018.sst
rocksdbtest/dbbench/CURRENT
rocksdbtest/dbbench/IDENTITY
rocksdbtest/dbbench/MANIFEST-000004
rocksdbtest/dbbench/OPTIONS-000007
```
