### PR TITLE
fs: consistent view when zone full

### DIFF
--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -65,6 +65,8 @@ void Zone::CloseWR() {
   assert(open_for_write_);
   open_for_write_ = false;
 
+  const std::lock_guard<std::mutex> lock(zbd_->zone_resources_mtx_);
+
   if (Close().ok()) {
     zbd_->NotifyIOZoneClosed();
   }
@@ -333,13 +335,11 @@ IOStatus ZonedBlockDevice::Open(bool readonly, bool exclusive) {
 }
 
 void ZonedBlockDevice::NotifyIOZoneFull() {
-  const std::lock_guard<std::mutex> lock(zone_resources_mtx_);
   active_io_zones_--;
   zone_resources_.notify_one();
 }
 
 void ZonedBlockDevice::NotifyIOZoneClosed() {
-  const std::lock_guard<std::mutex> lock(zone_resources_mtx_);
   open_io_zones_--;
   zone_resources_.notify_one();
 }

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -79,7 +79,6 @@ class ZonedBlockDevice {
   std::atomic<long> active_io_zones_;
   std::atomic<long> open_io_zones_;
   std::condition_variable zone_resources_;
-  std::mutex zone_resources_mtx_; /* Protects active/open io zones */
 
   unsigned int max_nr_active_io_zones_;
   unsigned int max_nr_open_io_zones_;
@@ -125,6 +124,8 @@ class ZonedBlockDevice {
   void NotifyIOZoneClosed();
 
   void EncodeJson(std::ostream &json_stream);
+
+  std::mutex zone_resources_mtx_; /* Protects active/open io zones */
 
  private:
   std::string ErrorToString(int err);


### PR DESCRIPTION
AllocateZone might mistakenly assume fully-written zone
is available to use. This is also an issue caused by a race
condition, and will make AllocateZone return nullptr
in rare cases (but actually might happen once a day when
active zone number is close to limit).

A simple fix is to hold the zone_resources_mtx_ throughout
the CloseWR function, instead of taking it twice inside to
NotifyIOZone{Full|Closed}. Therefore, AllocateZone always sees
a consistent state.

Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>
(just added more info from Alex to the commit message)

Signed-off-by: Alex Chi <iskyzh@gmail.com>