### PR TITLE
ci: add zenfs directory as part of lint check.

### DIFF
--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -16,4 +16,4 @@ jobs:
       uses: jidicula/clang-format-action@v3.4.0
       with:
         clang-format-version: '11'
-        check-path: 'fs'
+        check-path: .


### PR DESCRIPTION
Only zenfs/fs was being checked earlier,
now all .c/.cc files will be part of the lint check.

Signed-off-by: Aravind Ramesh <aravind.ramesh@wdc.com>