### PR TITLE
Inline extents

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -228,8 +228,8 @@ void ZenFS::LogFiles() {
     ZoneFile* zFile = it->second;
     std::vector<ZoneExtent*> extents = zFile->GetExtents();
 
-    Info(logger_, "    %-45s sz: %lu lh: %d", it->first.c_str(),
-         zFile->GetFileSize(), zFile->GetWriteLifeTimeHint());
+    Info(logger_, "    %-45s sz: %lu lh: %d sparse: %u", it->first.c_str(),
+         zFile->GetFileSize(), zFile->GetWriteLifeTimeHint(), zFile->IsSparse());
     for (unsigned int i = 0; i < extents.size(); i++) {
       ZoneExtent* extent = extents[i];
       Info(logger_, "          Extent %u {start=0x%lx, zone=%u, len=%u} ", i,
@@ -473,6 +473,7 @@ IOStatus ZenFS::NewWritableFile(const std::string& fname,
 
   zoneFile = new ZoneFile(zbd_, fname, next_file_id_++);
   zoneFile->SetFileModificationTime(time(0));
+  zoneFile->SetSparse(!file_opts.use_direct_writes);
 
   /* Persist the creation of the file */
   s = SyncFileMetadata(zoneFile);

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -219,6 +219,23 @@ ZenFS::~ZenFS() {
   delete zbd_;
 }
 
+void ZenFS::Repair() {
+  std::map<std::string, ZoneFile*>::iterator it;
+  for (it = files_.begin(); it != files_.end(); it++) {
+    const char *filename = it->first.c_str();
+    ZoneFile* zFile = it->second;
+    if (zFile->HasActiveExtent()) {
+      fprintf(stderr, "Recovering data for: %s \n", filename);
+      IOStatus s = zFile->Recover();
+      if (!s.ok()) {
+        fprintf(stderr, "   Recovery failed\n");
+      } else {
+        fprintf(stderr, "   Recovery ok\n");
+      }
+    }
+  }
+}
+
 void ZenFS::LogFiles() {
   std::map<std::string, ZoneFile*>::iterator it;
   uint64_t total_size = 0;
@@ -239,9 +256,6 @@ void ZenFS::LogFiles() {
 
       total_size += extent->length_;
     }
-
-    if (zFile->HasActiveExtent())
-      fprintf(stderr, "Needs recovery: %s \n", it->first.c_str());
   }
   Info(logger_, "Sum of all files: %lu MB of data \n",
        total_size / (1024 * 1024));
@@ -964,6 +978,9 @@ Status ZenFS::Mount(bool readonly) {
       valid_logs[i].reset();
     }
   }
+
+  // TODO: handle unsuccessful repair
+  Repair();
 
   if (readonly) {
     Info(logger_, "Mounting READ ONLY");

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -239,6 +239,9 @@ void ZenFS::LogFiles() {
 
       total_size += extent->length_;
     }
+
+    if (zFile->HasActiveExtent())
+      fprintf(stderr, "Needs recovery: %s \n", it->first.c_str());
   }
   Info(logger_, "Sum of all files: %lu MB of data \n",
        total_size / (1024 * 1024));

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -161,6 +161,7 @@ class ZenFS : public FileSystemWrapper {
   ZoneFile* GetFileInternal(std::string fname);
   ZoneFile* GetFile(std::string fname);
   IOStatus DeleteFile(std::string fname);
+  void Repair();
 
  public:
   explicit ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -112,7 +112,7 @@ class ZenFS : public FileSystemWrapper {
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }
 
-  struct MetadataWriter : public ZonedWritableFile::MetadataWriter {
+  struct ZenFSMetadataWriter : public MetadataWriter {
     ZenFS* zenFS;
     IOStatus Persist(ZoneFile* zoneFile) {
       Debug(zenFS->GetLogger(), "Syncing metadata for: %s",
@@ -121,7 +121,7 @@ class ZenFS : public FileSystemWrapper {
     }
   };
 
-  MetadataWriter metadata_writer_;
+  ZenFSMetadataWriter metadata_writer_;
 
   enum ZenFSTag : uint32_t {
     kCompleteFilesSnapshot = 1,

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -569,9 +569,9 @@ IOStatus ZonedWritableFile::Fsync(const IOOptions& /*options*/,
   return zoneFile_->PersistMetadata();
 }
 
-IOStatus ZonedWritableFile::Sync(const IOOptions& options,
-                                 IODebugContext* dbg) {
-  return Fsync(options, dbg);
+IOStatus ZonedWritableFile::Sync(const IOOptions& /*options*/,
+                                 IODebugContext* /*dbg*/) {
+  return DataSync();
 }
 
 IOStatus ZonedWritableFile::Flush(const IOOptions& /*options*/,
@@ -580,9 +580,9 @@ IOStatus ZonedWritableFile::Flush(const IOOptions& /*options*/,
 }
 
 IOStatus ZonedWritableFile::RangeSync(uint64_t offset, uint64_t nbytes,
-                                      const IOOptions& options,
-                                      IODebugContext* dbg) {
-  if (wp < offset + nbytes) return Fsync(options, dbg);
+                                      const IOOptions& /*options*/,
+                                      IODebugContext* /*dbg*/) {
+  if (wp < offset + nbytes) return DataSync();
 
   return IOStatus::OK();
 }

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -385,7 +385,10 @@ IOStatus ZoneFile::AllocateNewZone() {
     }
     extent_start_ = active_zone_->wp_;
     extent_filepos_ = fileSize;
-    return IOStatus::OK();
+
+    /* Persist metadata so we can recover the active extent using
+       the zone write pointer in case there is a crash before syncing */
+    return PersistMetadata();
 }
 
 /* Assumes that data and size are block aligned */

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -60,6 +60,7 @@ enum ZoneFileTag : uint32_t {
   kExtent = 5,
   kModificationTime = 6,
   kActiveExtentStart = 7,
+  kIsSparse = 8,
 };
 
 void ZoneFile::EncodeTo(std::string* output, uint32_t extent_start) {
@@ -94,6 +95,9 @@ void ZoneFile::EncodeTo(std::string* output, uint32_t extent_start) {
   PutFixed32(output, kActiveExtentStart);
   PutFixed64(output, extent_start_);
 
+  if (is_sparse_) {
+    PutFixed32(output, kIsSparse);
+  }
 }
 
 void ZoneFile::EncodeJson(std::ostream& json_stream) {
@@ -174,6 +178,9 @@ Status ZoneFile::DecodeFrom(Slice* input) {
           return Status::Corruption("ZoneFile", "Active extent start");
         extent_start_ = es;
         break;
+      case kIsSparse:
+        is_sparse_ = true;
+        break;
       default:
         return Status::Corruption("ZoneFile", "Unexpected tag");
     }
@@ -200,6 +207,7 @@ Status ZoneFile::MergeUpdate(ZoneFile* update) {
     extents_.push_back(new ZoneExtent(extent->start_, extent->length_, zone));
   }
 
+  is_sparse_ = update->IsSparse();
   MetadataSynced();
 
   return Status::OK();
@@ -347,7 +355,6 @@ IOStatus ZoneFile::PositionedRead(uint64_t offset, size_t n, Slice* result,
       }
       r_off = extent->start_;
       extent_end = extent->start_ + extent->length_;
-      assert(((size_t)r_off % zbd_->GetBlockSize()) == 0);
     }
   }
 
@@ -391,8 +398,64 @@ IOStatus ZoneFile::AllocateNewZone() {
     return PersistMetadata();
 }
 
+/* Byte-aligned, sparse writes with inline metadata
+   the caller reserves 8 bytes of data for a size header */
+IOStatus ZoneFile::SparseAppend(char* sparse_buffer, uint32_t data_size) {
+  uint32_t left = data_size;
+  uint32_t wr_size;
+  uint32_t block_sz = GetBlockSize();
+  IOStatus s;
+
+  // TODO: insert start addr here
+
+  if (active_zone_ == NULL) {
+    s = AllocateNewZone();
+    if (!s.ok())
+      return s;
+  }
+
+  while (left) {
+    wr_size = left + ZoneFile::SPARSE_HEADER_SIZE;
+    if (wr_size > active_zone_->capacity_) wr_size = active_zone_->capacity_;
+
+    /* Pad to the next block boundary if needed */
+    uint32_t align = wr_size % block_sz;
+    uint32_t pad_sz = 0;
+
+    align = wr_size % block_sz;
+    if (align) pad_sz = block_sz - align;
+    if (pad_sz) memset(sparse_buffer + wr_size, 0x0, pad_sz);
+
+    uint64_t extent_length = wr_size - ZoneFile::SPARSE_HEADER_SIZE;
+    EncodeFixed64(sparse_buffer, extent_length);
+
+    s = active_zone_->Append(sparse_buffer, wr_size + pad_sz);
+    if (!s.ok()) return s;
+
+    extents_.push_back(new ZoneExtent(extent_start_ + ZoneFile::SPARSE_HEADER_SIZE,
+                                      extent_length, active_zone_));
+
+    extent_start_ = active_zone_->wp_;
+    active_zone_->used_capacity_ += extent_length;
+    fileSize += extent_length;
+    left -= extent_length;
+
+    if (active_zone_->capacity_ == 0) {
+      if (left) {
+        memcpy((void *)(sparse_buffer + ZoneFile::SPARSE_HEADER_SIZE), (void *)(sparse_buffer + wr_size), left);
+      }
+      active_zone_->CloseWR();
+      s = AllocateNewZone();
+      if (!s.ok())
+        return s;
+    }
+  }
+
+  return IOStatus::OK();
+}
+
 /* Assumes that data and size are block aligned */
-IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
+IOStatus ZoneFile::Append(void* data, int data_size) {
   uint32_t left = data_size;
   uint32_t wr_size, offset = 0;
   IOStatus s;
@@ -424,7 +487,6 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
     offset += wr_size;
   }
 
-  fileSize -= (data_size - valid_size);
   return IOStatus::OK();
 }
 
@@ -441,17 +503,25 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
 
   buffered = _buffered;
   block_sz = zbd->GetBlockSize();
-  buffer_sz = block_sz * 256;
-  buffer_pos = 0;
-
   zoneFile_ = zoneFile;
+  buffer_pos = 0;
+  sparse_buffer = nullptr;
+  buffer = nullptr;
 
   if (buffered) {
-    int ret = posix_memalign((void**)&buffer, sysconf(_SC_PAGESIZE), buffer_sz);
+    size_t sparse_buffer_sz;
 
-    if (ret) buffer = nullptr;
+    sparse_buffer_sz = 1024 * 1024 + block_sz; /* one extra block size for padding */
+    int ret = posix_memalign((void**)&sparse_buffer, sysconf(_SC_PAGESIZE), sparse_buffer_sz);
 
-    assert(buffer != nullptr);
+    if (ret) sparse_buffer = nullptr;
+
+    assert(sparse_buffer != nullptr);
+
+    buffer_sz = sparse_buffer_sz - ZoneFile::SPARSE_HEADER_SIZE - block_sz;
+    buffer = sparse_buffer + ZoneFile::SPARSE_HEADER_SIZE;
+
+    zoneFile_->SetSparse(true);
   }
 
   zoneFile_->OpenWR(metadata_writer);
@@ -459,7 +529,7 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
 
 ZonedWritableFile::~ZonedWritableFile() {
   zoneFile_->CloseWR();
-  if (buffered) free(buffer);
+  if (buffered) free(sparse_buffer);
 };
 
 MetadataWriter::~MetadataWriter() {}
@@ -475,13 +545,20 @@ IOStatus ZonedWritableFile::Fsync(const IOOptions& /*options*/,
                                   IODebugContext* /*dbg*/) {
   IOStatus s;
 
-  buffer_mtx_.lock();
-  s = FlushBuffer();
-  buffer_mtx_.unlock();
-  if (!s.ok()) {
-    return s;
+  if (buffered) {
+    buffer_mtx_.lock();
+    /* Flushing the buffer will result in a new extent added to the list*/
+    s = FlushBuffer();
+    buffer_mtx_.unlock();
+    if (!s.ok()) {
+      return s;
+    }
+  } else {
+    /* For direct writes, there is no buffer to flush, we just need to persist
+       the current extent */
+    zoneFile_->PushExtent();
   }
-  zoneFile_->PushExtent();
+
   return zoneFile_->PersistMetadata();
 
 }
@@ -513,18 +590,12 @@ IOStatus ZonedWritableFile::Close(const IOOptions& options,
 }
 
 IOStatus ZonedWritableFile::FlushBuffer() {
-  uint32_t align, pad_sz = 0, wr_sz;
   IOStatus s;
 
-  if (!buffer_pos) return IOStatus::OK();
+  if (buffer_pos == 0) return IOStatus::OK();
 
-  align = buffer_pos % block_sz;
-  if (align) pad_sz = block_sz - align;
-
-  if (pad_sz) memset((char*)buffer + buffer_pos, 0x0, pad_sz);
-
-  wr_sz = buffer_pos + pad_sz;
-  s = zoneFile_->Append((char*)buffer, wr_sz, buffer_pos);
+  s = zoneFile_->SparseAppend(sparse_buffer,
+                              buffer_pos);
   if (!s.ok()) {
     return s;
   }
@@ -536,59 +607,29 @@ IOStatus ZonedWritableFile::FlushBuffer() {
 }
 
 IOStatus ZonedWritableFile::BufferedWrite(const Slice& slice) {
-  uint32_t buffer_left = buffer_sz - buffer_pos;
   uint32_t data_left = slice.size();
   char* data = (char*)slice.data();
-  uint32_t tobuffer;
-  int blocks, aligned_sz;
-  int ret;
-  void* alignbuf;
   IOStatus s;
 
-  if (buffer_pos || data_left <= buffer_left) {
-    if (data_left < buffer_left) {
-      tobuffer = data_left;
-    } else {
-      tobuffer = buffer_left;
+  while (data_left) {
+    uint32_t buffer_left = buffer_sz - buffer_pos;
+    uint32_t to_buffer;
+
+    if (!buffer_left) {
+      s = FlushBuffer();
+      if (!s.ok()) return s;
+      buffer_left = buffer_sz;
     }
 
-    memcpy(buffer + buffer_pos, data, tobuffer);
-    buffer_pos += tobuffer;
-    data_left -= tobuffer;
-
-    if (!data_left) return IOStatus::OK();
-
-    data += tobuffer;
-  }
-
-  if (buffer_pos == buffer_sz) {
-    s = FlushBuffer();
-    if (!s.ok()) return s;
-  }
-
-  if (data_left >= buffer_sz) {
-    blocks = data_left / block_sz;
-    aligned_sz = block_sz * blocks;
-
-    ret = posix_memalign(&alignbuf, sysconf(_SC_PAGESIZE), aligned_sz);
-    if (ret) {
-      return IOStatus::IOError("failed allocating alignment write buffer\n");
+    to_buffer = data_left;
+    if (to_buffer > buffer_left) {
+      to_buffer = buffer_left;
     }
 
-    memcpy(alignbuf, data, aligned_sz);
-    s = zoneFile_->Append(alignbuf, aligned_sz, aligned_sz);
-    free(alignbuf);
-
-    if (!s.ok()) return s;
-
-    wp += aligned_sz;
-    data_left -= aligned_sz;
-    data += aligned_sz;
-  }
-
-  if (data_left) {
-    memcpy(buffer, data, data_left);
-    buffer_pos = data_left;
+    memcpy(buffer + buffer_pos, data, to_buffer);
+    buffer_pos += to_buffer;
+    data_left -= to_buffer;
+    data += to_buffer;
   }
 
   return IOStatus::OK();
@@ -604,7 +645,7 @@ IOStatus ZonedWritableFile::Append(const Slice& data,
     s = BufferedWrite(data);
     buffer_mtx_.unlock();
   } else {
-    s = zoneFile_->Append((void*)data.data(), data.size(), data.size());
+    s = zoneFile_->Append((void*)data.data(), data.size());
     if (s.ok()) wp += data.size();
   }
 
@@ -626,7 +667,7 @@ IOStatus ZonedWritableFile::PositionedAppend(const Slice& data, uint64_t offset,
     s = BufferedWrite(data);
     buffer_mtx_.unlock();
   } else {
-    s = zoneFile_->Append((void*)data.data(), data.size(), data.size());
+    s = zoneFile_->Append((void*)data.data(), data.size());
     if (s.ok()) wp += data.size();
   }
 

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -88,6 +88,7 @@ class ZoneFile {
                           char* scratch, bool direct);
   ZoneExtent* GetExtent(uint64_t file_offset, uint64_t* dev_offset);
   void PushExtent();
+  IOStatus AllocateNewZone();
 
   void EncodeTo(std::string* output, uint32_t extent_start);
   void EncodeUpdateTo(std::string* output) {

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -123,6 +123,13 @@ class ZoneFile {
   void SetSparse(bool is_sparse) { is_sparse_ = is_sparse; };
   uint64_t HasActiveExtent() { return extent_start_ != NO_EXTENT; };
   uint64_t GetExtentStart() { return extent_start_; };
+
+  IOStatus Recover();
+
+ private:
+
+  IOStatus RecoverSparseExtents(uint64_t start, uint64_t end, Zone *zone);
+
 };
 
 class ZonedWritableFile : public FSWritableFile {

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -172,6 +172,7 @@ class ZonedWritableFile : public FSWritableFile {
  private:
   IOStatus BufferedWrite(const Slice& data);
   IOStatus FlushBuffer();
+  IOStatus DataSync();
 
   bool buffered;
   char* sparse_buffer;

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -121,6 +121,8 @@ class ZoneFile {
 
   bool IsSparse() { return is_sparse_; };
   void SetSparse(bool is_sparse) { is_sparse_ = is_sparse; };
+  uint64_t HasActiveExtent() { return extent_start_ != NO_EXTENT; };
+  uint64_t GetExtentStart() { return extent_start_; };
 };
 
 class ZonedWritableFile : public FSWritableFile {

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -39,23 +39,29 @@ class ZoneExtent {
 };
 
 class ZoneFile {
- protected:
+
+ private:
+  const uint64_t NO_EXTENT = 0xffffffffffffffff;
+
   ZonedBlockDevice* zbd_;
+
   std::vector<ZoneExtent*> extents_;
+
   Zone* active_zone_;
-  uint64_t extent_start_;
-  uint64_t extent_filepos_;
+  uint64_t extent_start_ = NO_EXTENT;
+  uint64_t extent_filepos_ = 0;
 
   Env::WriteLifeTimeHint lifetime_;
   uint64_t fileSize;
   std::string filename_;
   uint64_t file_id_;
 
-  uint32_t nr_synced_extents_;
+  uint32_t nr_synced_extents_ = 0;
   bool open_for_wr_ = false;
   time_t m_time_;
 
  public:
+
   explicit ZoneFile(ZonedBlockDevice* zbd, std::string filename,
                     uint64_t file_id_);
 

--- a/tests/staging/0002_fillrandom_sync.sh
+++ b/tests/staging/0002_fillrandom_sync.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-WORKLOAD_SZ=10000000000
+WORKLOAD_SZ=1000000000
 
 echo "" > $TEST_OUT
 
-for VALUE_SIZE in 2000 8000; do
+for VALUE_SIZE in 1000 2000 4000; do
   NUM=$(( $WORKLOAD_SZ / $VALUE_SIZE ))
   DB_BENCH_PARAMS="--benchmarks=fillrandom --num=$NUM --value_size=$VALUE_SIZE --compression_type=none --sync=1 --histogram $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
   echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" >> $TEST_OUT

--- a/tests/staging/0002_fillrandom_sync.sh
+++ b/tests/staging/0002_fillrandom_sync.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+WORKLOAD_SZ=10000000000
+
+echo "" > $TEST_OUT
+
+for VALUE_SIZE in 2000 8000; do
+  NUM=$(( $WORKLOAD_SZ / $VALUE_SIZE ))
+  DB_BENCH_PARAMS="--benchmarks=fillrandom --num=$NUM --value_size=$VALUE_SIZE --compression_type=none --sync=1 --histogram $FS_PARAMS $DB_BENCH_EXTRA_PARAMS"
+  echo "# Running db_bench with parameters: $DB_BENCH_PARAMS" >> $TEST_OUT
+  $TOOLS_DIR/db_bench $DB_BENCH_PARAMS >> $TEST_OUT
+  RES=$?
+  if [ $RES -ne 0 ]; then
+    exit $RES
+  fi
+done
+
+exit 0


### PR DESCRIPTION
Reduce metadata writes for non-direct(buffered) writable files(e.g WAL files) by persisting the data length along with the data when flushing the write buffers. By doing this we only need to do a meta data write sync when switching to a new zone. 

Also allow for recovery of not-yet-synced written data of non-buffered(direct) writable files (e.g. SSTs) using the write pointer of the active extent.

This would minimize the impact of metadata rolls which is a problem if every write is synced. see #61 

This is a breaking/non-backwards compatible on-disk-format change, so this should be merged to master when we step format version next time (so this PR targets the for_v2 branch for now)