### PR TITLE
More convenient for test the rocksdb with shell : run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ echo deadline > /sys/class/block/<zoned block device>/queue/scheduler
 ```
 
 If you want to run db_bench below, there is a shell for you to run db_bench 
-with a 'long' and 'qucik' performance without execute the left command.
+with a 'long' and 'qucik' performance without execute left commands.
 `cd tests; ./zenfs_base_performance.sh <zoned block device name>`
 
 ## Creating a ZenFS file system

--- a/tests/get_good_db_bench_params_for_zenfs.sh
+++ b/tests/get_good_db_bench_params_for_zenfs.sh
@@ -8,3 +8,4 @@ CAP_SECTORS=$(blkzone report -c 5 /dev/$DEV | grep -oP '(?<=cap )[0-9xa-f]+' | h
 ZONE_CAP=$(($CAP_SECTORS * 512))
 WB_SIZE=$(( 2 * 1024 * 1024 * 1024))
 echo "--target_file_size_base=$(($ZONE_CAP * 2 * 95 / 100)) --use_direct_io_for_flush_and_compaction --max_bytes_for_level_multiplier=4 --max_background_jobs=8 --use_direct_reads --write_buffer_size=$WB_SIZE"
+


### PR DESCRIPTION
This path is a simple fix for the rocksdb test shell like : $FS_PARAMS $DB_BENCH_EXTRA_PARAMS in some shell is invalid( not init).

Then the add code is to produce the db options by get_good_db_bench_params_for_zenfs.sh and init the two params into the test shell. 

We could simple use it below.

```shell
# How to use the shell for convenient test
# Before: 
# 1. run with the 'root'
# 2. the device should have run : 
#    ../util/zenfs mkfs --zbd=<zoned block device> --aux_path=<path to store LOG and LOCK files>
#
# Run:
#   sh run.sh <log-dir-name> <TEST-DIR> <DEVICE-NAME>
#   eg: sh run.sh long-result long_performance nvme2n1
```


zhanghhuigui@kuaishou.com