### PR TITLE
fix: Prevent data race when closing writable zone

### DIFF
--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -54,6 +54,8 @@ class Zone {
   bool IsEmpty();
   uint64_t GetZoneNr();
   uint64_t GetCapacityLeft();
+  bool SynchronousIsOpenForWrite();
+  void SynchronousSetOpenForWrite(bool value);
 
   void EncodeJson(std::ostream &json_stream);
 


### PR DESCRIPTION
This patch prevents a race condition on Zone::open_for_write_ by locking on
access to the field.

Signed-off-by: Andreas Hindborg <andreas.hindborg@wdc.com>