### PR TITLE
feat: Add runtime check for BLKCLOSEZONE ioctl

### DIFF
--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -129,6 +129,7 @@ class ZonedBlockDevice {
 
  private:
   std::string ErrorToString(int err);
+  IOStatus TestZoneClose(struct zbd_zone *zone);
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
ZenFS requires a kernel with support for BLKCLOSEZONE ioctl. This patch adds a
check for this ioctl when a zoned block device is opened by ZenFS.

Signed-off-by: Andreas Hindborg <andreas.hindborg@wdc.com>

Closes #66 