### PR TITLE
Add busy flag to `Zone`

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -277,8 +277,8 @@ IOStatus ZenFS::WriteEndRecord(ZenMetaLog* meta_log) {
 
 /* Assumes the files_mtx_ is held */
 IOStatus ZenFS::RollMetaZoneLocked() {
-  ZenMetaLog* new_meta_log;
-  Zone *new_meta_zone, *old_meta_zone;
+  std::unique_ptr<ZenMetaLog> new_meta_log, old_meta_log;
+  Zone* new_meta_zone;
   IOStatus s;
 
   new_meta_zone = zbd_->AllocateMetaZone();
@@ -289,16 +289,18 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   }
 
   Info(logger_, "Rolling to metazone %d\n", (int)new_meta_zone->GetZoneNr());
-  new_meta_log = new ZenMetaLog(zbd_, new_meta_zone);
+  new_meta_log.reset(new ZenMetaLog(zbd_, new_meta_zone));
 
-  old_meta_zone = meta_log_->GetZone();
-  old_meta_zone->open_for_write_ = false;
+  old_meta_log.swap(this->meta_log_);
+  this->meta_log_.swap(new_meta_log);
+
+  old_meta_log->GetZone()->open_for_write_ = false;
 
   /* Write an end record and finish the meta data zone if there is space left */
-  if (old_meta_zone->GetCapacityLeft()) WriteEndRecord(meta_log_.get());
-  if (old_meta_zone->GetCapacityLeft()) old_meta_zone->Finish();
-
-  meta_log_.reset(new_meta_log);
+  if (old_meta_log->GetZone()->GetCapacityLeft())
+    WriteEndRecord(old_meta_log.get());
+  if (old_meta_log->GetZone()->GetCapacityLeft())
+    old_meta_log->GetZone()->Finish();
 
   std::string super_string;
   superblock_->EncodeTo(&super_string);
@@ -313,7 +315,7 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   s = WriteSnapshotLocked(meta_log_.get());
 
   /* We've rolled successfully, we can reset the old zone now */
-  if (s.ok()) old_meta_zone->Reset();
+  if (s.ok()) old_meta_log->GetZone()->Reset();
 
   return s;
 }
@@ -875,6 +877,7 @@ Status ZenFS::Mount(bool readonly) {
     std::string scratch;
     Slice super_record;
 
+    assert(z->SetBusy());
     log.reset(new ZenMetaLog(zbd_, z));
 
     if (!log->ReadRecord(&super_record, &scratch).ok()) continue;
@@ -1004,8 +1007,13 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold) {
   zbd_->ResetUnusedIOZones();
 
   for (const auto mz : metazones) {
+    assert(mz->SetBusy());
     if (mz->Reset().ok()) {
-      if (!meta_zone) meta_zone = mz;
+      if (!meta_zone) {
+        meta_zone = mz;
+      } else {
+        assert(mz->UnsetBusy());
+      }
     } else {
       Warn(logger_, "Failed to reset meta zone\n");
     }

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -875,7 +875,7 @@ Status ZenFS::Mount(bool readonly) {
     std::string scratch;
     Slice super_record;
 
-    bool ok = z->SetBusy();
+    bool ok = z->Acquire();
     assert(ok);
     _unused(ok);
 
@@ -1008,7 +1008,7 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold) {
   zbd_->ResetUnusedIOZones();
 
   for (const auto mz : metazones) {
-    bool ok = mz->SetBusy();
+    bool ok = mz->Acquire();
     assert(ok);
     _unused(ok);
 
@@ -1016,7 +1016,7 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold) {
       if (!meta_zone) {
         meta_zone = mz;
       } else {
-        ok = mz->UnsetBusy();
+        ok = mz->Release();
         assert(ok);
       }
     } else {

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -294,8 +294,6 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   old_meta_log.swap(this->meta_log_);
   this->meta_log_.swap(new_meta_log);
 
-  old_meta_log->GetZone()->open_for_write_ = false;
-
   /* Write an end record and finish the meta data zone if there is space left */
   if (old_meta_log->GetZone()->GetCapacityLeft())
     WriteEndRecord(old_meta_log.get());

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -875,7 +875,10 @@ Status ZenFS::Mount(bool readonly) {
     std::string scratch;
     Slice super_record;
 
-    assert(z->SetBusy());
+    bool ok = z->SetBusy();
+    assert(ok);
+    _unused(ok);
+
     log.reset(new ZenMetaLog(zbd_, z));
 
     if (!log->ReadRecord(&super_record, &scratch).ok()) continue;
@@ -1005,12 +1008,16 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold) {
   zbd_->ResetUnusedIOZones();
 
   for (const auto mz : metazones) {
-    assert(mz->SetBusy());
+    bool ok = mz->SetBusy();
+    assert(ok);
+    _unused(ok);
+
     if (mz->Reset().ok()) {
       if (!meta_zone) {
         meta_zone = mz;
       } else {
-        assert(mz->UnsetBusy());
+        ok = mz->UnsetBusy();
+        assert(ok);
       }
     } else {
       Warn(logger_, "Failed to reset meta zone\n");

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "debug.h"
 #include "io_zenfs.h"
 #include "rocksdb/env.h"
 #include "rocksdb/file_system.h"
@@ -87,7 +88,11 @@ class ZenMetaLog {
     read_pos_ = zone->start_;
   }
 
-  virtual ~ZenMetaLog() { assert(zone_->UnsetBusy()); }
+  virtual ~ZenMetaLog() {
+    bool ok = zone_->UnsetBusy();
+    assert(ok);
+    _unused(ok);
+  }
 
   IOStatus AddRecord(const Slice& slice);
   IOStatus ReadRecord(Slice* record, std::string* scratch);

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -89,7 +89,7 @@ class ZenMetaLog {
   }
 
   virtual ~ZenMetaLog() {
-    bool ok = zone_->UnsetBusy();
+    bool ok = zone_->Release();
     assert(ok);
     _unused(ok);
   }

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -80,6 +80,7 @@ class ZenMetaLog {
 
  public:
   ZenMetaLog(ZonedBlockDevice* zbd, Zone* zone) {
+    assert(zone->IsBusy());
     zbd_ = zbd;
     zone_ = zone;
     zone_->open_for_write_ = true;
@@ -87,7 +88,10 @@ class ZenMetaLog {
     read_pos_ = zone->start_;
   }
 
-  virtual ~ZenMetaLog() { zone_->open_for_write_ = false; }
+  virtual ~ZenMetaLog() {
+    zone_->open_for_write_ = false;
+    assert(zone_->UnsetBusy());
+  }
 
   IOStatus AddRecord(const Slice& slice);
   IOStatus ReadRecord(Slice* record, std::string* scratch);

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -83,15 +83,11 @@ class ZenMetaLog {
     assert(zone->IsBusy());
     zbd_ = zbd;
     zone_ = zone;
-    zone_->open_for_write_ = true;
     bs_ = zbd_->GetBlockSize();
     read_pos_ = zone->start_;
   }
 
-  virtual ~ZenMetaLog() {
-    zone_->open_for_write_ = false;
-    assert(zone_->UnsetBusy());
-  }
+  virtual ~ZenMetaLog() { assert(zone_->UnsetBusy()); }
 
   IOStatus AddRecord(const Slice& slice);
   IOStatus ReadRecord(Slice* record, std::string* scratch);

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -361,7 +361,7 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
   if (!active_zone_) {
     Zone* zone = zbd_->AllocateZone(lifetime_);
     if (!zone) {
-      return IOStatus::NoSpace("Zone allocation failure\n");
+      return IOStatus::NoSpace("Zone allocation failure, no active zone\n");
     }
     this->SetActiveZone(zone);
     extent_start_ = active_zone_->wp_;
@@ -380,7 +380,8 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
 
       Zone* zone = zbd_->AllocateZone(lifetime_);
       if (!zone) {
-        return IOStatus::NoSpace("Zone allocation failure\n");
+        return IOStatus::NoSpace(
+            "Zone allocation failure, current zone full\n");
       }
       this->SetActiveZone(zone);
 

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -361,7 +361,8 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
   if (!active_zone_) {
     Zone* zone = zbd_->AllocateZone(lifetime_);
     if (!zone) {
-      return IOStatus::NoSpace("Zone allocation failure, no active zone\n");
+      return IOStatus::NoSpace(
+          "Out of space: Zone allocation failure while setting active zone");
     }
     this->SetActiveZone(zone);
     extent_start_ = active_zone_->wp_;
@@ -381,7 +382,8 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
       Zone* zone = zbd_->AllocateZone(lifetime_);
       if (!zone) {
         return IOStatus::NoSpace(
-            "Zone allocation failure, current zone full\n");
+            "Out of space: Zone allocation failure while replacing active "
+            "zone");
       }
       this->SetActiveZone(zone);
 

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -414,7 +414,7 @@ IOStatus ZoneFile::SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime) {
 
 void ZoneFile::ReleaseActiveZone() {
   assert(this->active_zone_ != nullptr);
-  bool ok = this->active_zone_->UnsetBusy();
+  bool ok = this->active_zone_->Release();
   assert(ok);
   _unused(ok);
   this->active_zone_ = nullptr;

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "debug.h"
 #include "rocksdb/env.h"
 #include "util/coding.h"
 
@@ -413,7 +414,9 @@ IOStatus ZoneFile::SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime) {
 
 void ZoneFile::ReleaseActiveZone() {
   assert(this->active_zone_ != nullptr);
-  assert(this->active_zone_->UnsetBusy());
+  bool ok = this->active_zone_->UnsetBusy();
+  assert(ok);
+  _unused(ok);
   this->active_zone_ = nullptr;
 }
 

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -225,8 +225,11 @@ ZoneFile::~ZoneFile() {
 
 void ZoneFile::CloseWR() {
   if (active_zone_) {
-    active_zone_->CloseWR();
-    active_zone_ = NULL;
+    IOStatus status = active_zone_->CloseWR();
+    this->ReleaseActiveZone();
+    if (status.ok()) {
+      zbd_->NotifyIOZoneClosed();
+    }
   }
   open_for_wr_ = false;
 }
@@ -355,11 +358,12 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
   uint32_t wr_size, offset = 0;
   IOStatus s;
 
-  if (active_zone_ == NULL) {
-    active_zone_ = zbd_->AllocateZone(lifetime_);
-    if (!active_zone_) {
+  if (!active_zone_) {
+    Zone* zone = zbd_->AllocateZone(lifetime_);
+    if (!zone) {
       return IOStatus::NoSpace("Zone allocation failure\n");
     }
+    this->SetActiveZone(zone);
     extent_start_ = active_zone_->wp_;
     extent_filepos_ = fileSize;
   }
@@ -368,11 +372,18 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
     if (active_zone_->capacity_ == 0) {
       PushExtent();
 
-      active_zone_->CloseWR();
-      active_zone_ = zbd_->AllocateZone(lifetime_);
-      if (!active_zone_) {
+      IOStatus status = active_zone_->CloseWR();
+      this->ReleaseActiveZone();
+      if (status.ok()) {
+        this->zbd_->NotifyIOZoneClosed();
+      }
+
+      Zone* zone = zbd_->AllocateZone(lifetime_);
+      if (!zone) {
         return IOStatus::NoSpace("Zone allocation failure\n");
       }
+      this->SetActiveZone(zone);
+
       extent_start_ = active_zone_->wp_;
       extent_filepos_ = fileSize;
     }
@@ -395,6 +406,18 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
 IOStatus ZoneFile::SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime) {
   lifetime_ = lifetime;
   return IOStatus::OK();
+}
+
+void ZoneFile::ReleaseActiveZone() {
+  assert(this->active_zone_ != nullptr);
+  assert(this->active_zone_->UnsetBusy());
+  this->active_zone_ = nullptr;
+}
+
+void ZoneFile::SetActiveZone(Zone* zone) {
+  assert(this->active_zone_ == nullptr);
+  assert(zone->IsBusy());
+  this->active_zone_ = zone;
 }
 
 ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -96,6 +96,10 @@ class ZoneFile {
 
   uint64_t GetID() { return file_id_; }
   size_t GetUniqueId(char* id, size_t max_size);
+
+ private:
+  void ReleaseActiveZone();
+  void SetActiveZone(Zone* zone);
 };
 
 class ZonedWritableFile : public FSWritableFile {

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -41,7 +41,6 @@ class Zone {
   uint64_t capacity_; /* remaining capacity */
   uint64_t max_capacity_;
   uint64_t wp_;
-  bool open_for_write_;
   Env::WriteLifeTimeHint lifetime_;
   std::atomic<long> used_capacity_;
 

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -55,12 +55,12 @@ class Zone {
   uint64_t GetZoneNr();
   uint64_t GetCapacityLeft();
   bool IsBusy() { return this->busy_.load(std::memory_order_relaxed); }
-  bool SetBusy() {
+  bool Acquire() {
     bool expected = false;
     return this->busy_.compare_exchange_strong(expected, true,
                                                std::memory_order_acq_rel);
   }
-  bool UnsetBusy() {
+  bool Release() {
     bool expected = true;
     return this->busy_.compare_exchange_strong(expected, false,
                                                std::memory_order_acq_rel);


### PR DESCRIPTION
This patch set prevents a race condition on `Zone::open_for_write_` by adding a busy
flag to the Zone structure. Writing the busy flag through class methods use
acquire/release ordering, while reading the flag uses relaxed ordering. That is, claiming or releasing a zone is a synchronization operation that involves previous and next owners of the zone.

With this patch, users of a zone must acquire ownership of the zone by setting the busy flag of the zone, before managing the zone.

The patch removes `Zone::open_for_write_` as it becomes redundant.

Supersedes #71 
Supersedes #46 