### PR TITLE
fs: Handle faulty Acquire and Release calles on zones.

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -278,10 +278,12 @@ IOStatus ZenFS::WriteEndRecord(ZenMetaLog* meta_log) {
 /* Assumes the files_mtx_ is held */
 IOStatus ZenFS::RollMetaZoneLocked() {
   std::unique_ptr<ZenMetaLog> new_meta_log, old_meta_log;
-  Zone* new_meta_zone;
+  Zone* new_meta_zone = nullptr;
   IOStatus s;
 
-  new_meta_zone = zbd_->AllocateMetaZone();
+  IOStatus status = zbd_->AllocateMetaZone(&new_meta_zone);
+  if (!status.ok()) return status;
+
   if (!new_meta_zone) {
     assert(false);  // TMP
     Error(logger_, "Out of metadata zones, we should go to read only now.");
@@ -876,10 +878,13 @@ Status ZenFS::Mount(bool readonly) {
     std::string scratch;
     Slice super_record;
 
-    bool ok = z->Acquire();
-    assert(ok);
-    (void)ok;
+    if (!z->Acquire()) {
+      assert(false);
+      return Status::Aborted("Could not aquire busy flag of zone" +
+                             std::to_string(z->GetZoneNr()));
+    }
 
+    // log takes the ownership of z's busy flag.
     log.reset(new ZenMetaLog(zbd_, z));
 
     if (!log->ReadRecord(&super_record, &scratch).ok()) continue;
@@ -985,7 +990,8 @@ Status ZenFS::Mount(bool readonly) {
 
   if (!readonly) {
     Info(logger_, "Resetting unused IO Zones..");
-    zbd_->ResetUnusedIOZones();
+    Status status = zbd_->ResetUnusedIOZones();
+    if (!status.ok()) return status;
     Info(logger_, "  Done");
   }
 
@@ -1006,22 +1012,29 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold) {
   }
 
   ClearFiles();
-  zbd_->ResetUnusedIOZones();
+  Status status = zbd_->ResetUnusedIOZones();
+  if (!status.ok()) return status;
 
   for (const auto mz : metazones) {
-    bool ok = mz->Acquire();
-    assert(ok);
-    (void)ok;
+    if (!mz->Acquire()) {
+      assert(false);
+      return Status::Aborted("Could not aquire busy flag of zone " +
+                             std::to_string(mz->GetZoneNr()));
+    }
 
     if (mz->Reset().ok()) {
-      if (!meta_zone) {
-        meta_zone = mz;
-      } else {
-        ok = mz->Release();
-        assert(ok);
-      }
+      if (!meta_zone) meta_zone = mz;
     } else {
       Warn(logger_, "Failed to reset meta zone\n");
+    }
+
+    if (meta_zone != mz) {
+      // for meta_zone == mz the ownership of mz's busy flag is passed to log.
+      if (!mz->Release()) {
+        assert(false);
+        return Status::Aborted("Could not unset busy flag of zone " +
+                               std::to_string(mz->GetZoneNr()));
+      }
     }
   }
 

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -88,6 +88,7 @@ class ZenMetaLog {
   }
 
   virtual ~ZenMetaLog() {
+    // TODO: report async error status
     bool ok = zone_->Release();
     assert(ok);
     (void)ok;

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -368,9 +368,7 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
   if (!active_zone_) {
     Zone* zone = nullptr;
     s = zbd_->AllocateZone(lifetime_, &zone);
-    if (!s.ok()) {
-      return s;
-    }
+    if (!s.ok()) return s;
 
     if (!zone) {
       return IOStatus::NoSpace(
@@ -387,18 +385,13 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
       PushExtent();
 
       s = active_zone_->CloseWR();
-      if (!s.ok()) {
-        return s;
-      }
+      if (!s.ok()) return s;
       ReleaseActiveZone();
       zbd_->NotifyIOZoneClosed();
 
       Zone* zone = nullptr;
       s = zbd_->AllocateZone(lifetime_, &zone);
-
-      if (!s.ok()) {
-        return s;
-      }
+      if (!s.ok()) return s;
 
       if (!zone) {
         return IOStatus::NoSpace(

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -69,6 +69,8 @@ class Zone {
   void EncodeJson(std::ostream &json_stream);
 
   IOStatus CloseWR(); /* Done writing */
+
+  inline IOStatus CheckRelease();
 };
 
 class ZonedBlockDevice {
@@ -110,7 +112,7 @@ class ZonedBlockDevice {
   Zone *GetIOZone(uint64_t offset);
 
   IOStatus AllocateZone(Env::WriteLifeTimeHint file_lifetime, Zone **out_zone);
-  Zone *AllocateMetaZone();
+  IOStatus AllocateMetaZone(Zone **out_meta_zone);
 
   uint64_t GetFreeSpace();
   uint64_t GetUsedSpace();
@@ -119,7 +121,7 @@ class ZonedBlockDevice {
   std::string GetFilename();
   uint32_t GetBlockSize();
 
-  void ResetUnusedIOZones();
+  Status ResetUnusedIOZones();
   void LogZoneStats();
   void LogZoneUsage();
 


### PR DESCRIPTION
For non-debug builds failing 'Acquire' and 'Release' calls where not
handled. Passing errors over to the calling function/application.

Reported-by: Hans Holmberg <hans.holmberg@wdc.com>
Suggested-by: Andreas Hindborg <andreas.hindborg@wdc.com>
Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>