### PR TITLE
Update error messages raised when open device fail

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1091,7 +1091,7 @@ Status NewZenFS(FileSystem** fs, const std::string& bdevname) {
   ZonedBlockDevice* zbd = new ZonedBlockDevice(bdevname, logger);
   IOStatus zbd_status = zbd->Open(false, true);
   if (!zbd_status.ok()) {
-    Error(logger, "Failed to open zoned block device: %s",
+    Error(logger, "mkfs: Failed to open zoned block device: %s",
           zbd_status.ToString().c_str());
     return Status::IOError(zbd_status.ToString());
   }

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -229,14 +229,15 @@ IOStatus ZonedBlockDevice::Open(bool readonly, bool exclusive) {
   }
 
   if (read_f_ < 0) {
-    return IOStatus::InvalidArgument("Failed to open zoned block device: " +
-                                     ErrorToString(errno));
+    return IOStatus::InvalidArgument(
+        "Failed to open zoned block device for read: " + ErrorToString(errno));
   }
 
   read_direct_f_ = zbd_open(filename_.c_str(), O_RDONLY | O_DIRECT, &info);
   if (read_direct_f_ < 0) {
-    return IOStatus::InvalidArgument("Failed to open zoned block device: " +
-                                     ErrorToString(errno));
+    return IOStatus::InvalidArgument(
+        "Failed to open zoned block device for direct read: " +
+        ErrorToString(errno));
   }
 
   if (readonly) {
@@ -244,8 +245,9 @@ IOStatus ZonedBlockDevice::Open(bool readonly, bool exclusive) {
   } else {
     write_f_ = zbd_open(filename_.c_str(), O_WRONLY | O_DIRECT, &info);
     if (write_f_ < 0) {
-      return IOStatus::InvalidArgument("Failed to open zoned block device: " +
-                                       ErrorToString(errno));
+      return IOStatus::InvalidArgument(
+          "Failed to open zoned block device for write: " +
+          ErrorToString(errno));
     }
   }
 


### PR DESCRIPTION
Make error messages unique for open device errors.