### PR TITLE
Allow extra compiler/linker flags when building zenfs utility

### DIFF
--- a/util/Makefile
+++ b/util/Makefile
@@ -5,13 +5,16 @@ TARGET = zenfs
 CC ?= gcc
 CXX ?= g++
 
-CPPFLAGS = $(shell pkg-config --cflags rocksdb)
+CXXFLAGS = $(shell pkg-config --cflags rocksdb)
 LIBS = $(shell pkg-config --static --libs rocksdb)
+
+CXXFLAGS +=  $(EXTRA_CXXFLAGS)
+LDFLAGS +=  $(EXTRA_LDFLAGS)
 
 all: $(TARGET)
 
 $(TARGET): $(TARGET).cc
-	$(CXX) $(CPPFLAGS) -o $(TARGET) $< $(LIBS)
+	$(CXX) $(CXXFLAGS) -o $(TARGET) $< $(LIBS) $(LDFLAGS)
 
 clean:
 	$(RM) $(TARGET)


### PR DESCRIPTION
When libzbd and librocksdb is not living in the same location, it is nice to be able to pass extra flags to the build script.