### PR TITLE
ci: Remove docker images after run

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -28,4 +28,5 @@ jobs:
           path: harness/rocksdb-context/rocksdb/plugin/zenfs
       - name: Run smoke tests
         run: cd harness && make NO_VAGRANT=1 results/zenfs-smoke.xml 
-      
+      - name: Remove docker images
+        run: docker image prune --force


### PR DESCRIPTION
Docker images pile up on the runner. This patch removes the images after the test has run.

We will move this to the harness eventually, but for now this will have to do.