### PR TITLE
fs: ensure extents are pushed

### DIFF
--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -472,6 +472,9 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
 }
 
 ZonedWritableFile::~ZonedWritableFile() {
+  IOOptions iopts;
+
+  Fsync(iopts, nullptr);
   IOStatus s = zoneFile_->CloseWR();
   if (buffered) free(buffer);
 


### PR DESCRIPTION
Add Fsync() in ZonedWritableFile destructor so that the extent
information is persisted. In some scenarios it can lead to
files without extent information but with a valid size.

Signed-off-by: Aravind Ramesh <Aravind.Ramesh@wdc.com>