### PR TITLE
fs: ensure ReopenWritableFile() matches rocksdb definition

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -460,35 +460,10 @@ IOStatus ZenFS::NewWritableFile(const std::string& fname,
                                 const FileOptions& file_opts,
                                 std::unique_ptr<FSWritableFile>* result,
                                 IODebugContext* /*dbg*/) {
-  IOStatus s;
-
   Debug(logger_, "New writable file: %s direct: %d\n", fname.c_str(),
         file_opts.use_direct_writes);
 
-  if (GetFile(fname) != nullptr) {
-    s = DeleteFile(fname);
-    if (!s.ok()) return s;
-  }
-
-  std::shared_ptr<ZoneFile> zoneFile(
-      new ZoneFile(zbd_, fname, next_file_id_++));
-  zoneFile->SetFileModificationTime(time(0));
-
-  /* Persist the creation of the file */
-  s = SyncFileMetadata(zoneFile);
-  if (!s.ok()) {
-    zoneFile.reset();
-    return s;
-  }
-
-  files_mtx_.lock();
-  files_.insert(std::make_pair(fname.c_str(), zoneFile));
-  files_mtx_.unlock();
-
-  result->reset(new ZonedWritableFile(zbd_, !file_opts.use_direct_writes,
-                                      zoneFile, &metadata_writer_));
-
-  return s;
+  return OpenWritableFile(fname, file_opts, result, nullptr, false);
 }
 
 IOStatus ZenFS::ReuseWritableFile(const std::string& fname,
@@ -516,16 +491,16 @@ IOStatus ZenFS::FileExists(const std::string& fname, const IOOptions& options,
   }
 }
 
+/* If the file does not exist, create a new one,
+ * else return the existing file
+ */
 IOStatus ZenFS::ReopenWritableFile(const std::string& fname,
-                                   const FileOptions& options,
+                                   const FileOptions& file_opts,
                                    std::unique_ptr<FSWritableFile>* result,
                                    IODebugContext* dbg) {
   Debug(logger_, "Reopen writable file: %s \n", fname.c_str());
 
-  if (GetFile(fname) != nullptr)
-    return NewWritableFile(fname, options, result, dbg);
-
-  return target()->NewWritableFile(fname, options, result, dbg);
+  return OpenWritableFile(fname, file_opts, result, dbg, true);
 }
 
 IOStatus ZenFS::GetChildren(const std::string& dir, const IOOptions& options,
@@ -568,6 +543,44 @@ IOStatus ZenFS::GetChildren(const std::string& dir, const IOOptions& options,
     }
   }
   files_mtx_.unlock();
+
+  return s;
+}
+
+IOStatus ZenFS::OpenWritableFile(const std::string& fname,
+                                 const FileOptions& file_opts,
+                                 std::unique_ptr<FSWritableFile>* result,
+                                 IODebugContext* /*dbg*/, bool reopen) {
+  IOStatus s;
+  std::shared_ptr<ZoneFile> zoneFile = GetFile(fname);
+
+  /* if reopen is true and the file exists, return it */
+  if (reopen && zoneFile != nullptr) {
+    result->reset(new ZonedWritableFile(zbd_, !file_opts.use_direct_writes,
+                                        zoneFile, &metadata_writer_));
+    return IOStatus::OK();
+  }
+
+  if (zoneFile != nullptr) {
+    s = DeleteFile(fname);
+    if (!s.ok()) return s;
+  }
+
+  zoneFile = std::make_shared<ZoneFile>(zbd_, fname, next_file_id_++);
+  zoneFile->SetFileModificationTime(time(0));
+
+  /* Persist the creation of the file */
+  s = SyncFileMetadata(zoneFile);
+  if (!s.ok()) {
+    zoneFile.reset();
+    return s;
+  }
+
+  std::lock_guard<std::mutex> file_lock(files_mtx_);
+  files_.insert(std::make_pair(fname.c_str(), zoneFile));
+
+  result->reset(new ZonedWritableFile(zbd_, !file_opts.use_direct_writes,
+                                      zoneFile, &metadata_writer_));
 
   return s;
 }

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -167,6 +167,12 @@ class ZenFS : public FileSystemWrapper {
   std::shared_ptr<ZoneFile> GetFile(std::string fname);
   IOStatus DeleteFile(std::string fname);
 
+ protected:
+  IOStatus OpenWritableFile(const std::string& fname,
+                            const FileOptions& file_opts,
+                            std::unique_ptr<FSWritableFile>* result,
+                            IODebugContext* dbg, bool reopen);
+
  public:
   explicit ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,
                  std::shared_ptr<Logger> logger);


### PR DESCRIPTION
RocksDB expects the api ReopenWritableFile() to return an existing
file and if the file is not present, create the file and return it.
Ensure ZenFS api adheres to it.

Signed-off-by: Aravind Ramesh<Aravind.Ramesh@wdc.com>