### PR TITLE
fs, util: Introducing semi automatic versioning for ZenFS.

### DIFF
--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -25,6 +25,7 @@ jobs:
       - name: Checkout zenfs
         uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           path: harness/rocksdb-context/rocksdb/plugin/zenfs
       - name: Run smoke tests
         run: cd harness && make NO_VAGRANT=1 results/zenfs-smoke.xml 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ util/zenfs
 fs/*.o
 fs/*.cc.d
 tests/results
+fs/version.h

--- a/generate-version.sh
+++ b/generate-version.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+REPO_ROOT=$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )
+cd $REPO_ROOT
+
+# 'git describe --abbrev=7 --dirty' will output a version in that looks like "v0.1.0-12-g3456789-dirty".
+VERSION=$(git describe --abbrev=7 --dirty)
+
+updateVersionFile () {
+  if [ "${#VERSION}" -gt 63 ]; then
+    echo "The 'git describe --abbrev=7 --dirty' generated version is longer than 63 chars, thus not fitting in the ZenFS superblock. Aborting!" >&2
+    return 1
+  fi
+  printf '#pragma once\n#define ZENFS_VERSION "%s"\n' \
+    $VERSION > $REPO_ROOT/fs/version.h
+  return 0
+}
+
+RET=0
+if [ -f "$REPO_ROOT/fs/version.h" ]; then
+  PERSISTED_VERSION=$(cat $REPO_ROOT/fs/version.h | grep ' ZENFS_VERSION ' | grep -o '".*"' | sed 's/"//g')
+
+  if [ "$PERSISTED_VERSION" != "$VERSION" ]; then
+    RET=$(updateVersionFile)
+  fi
+else
+  RET=$(updateVersionFile)
+fi
+
+exit $RET

--- a/util/zenfs.8
+++ b/util/zenfs.8
@@ -47,6 +47,14 @@ Restore files from a backup into ZenFS file system.
 .B dump
 Dump ZenFS metadata in JSON format.
 
+.TP
+.B fs-info
+Prints the contents of the current ZenFS superblock to stdout.
+.br
+The ZenFS version is set to "Not Available" if the superblock was created with a ZenFS version prior to the one that introduces this command.
+.br
+Otherwise the ZenFS version contains the 'git describe' version string from when it was build.
+
 .SH OPTIONS
 
 .TP
@@ -90,6 +98,10 @@ Restore zenfs filesystem from a backup.
 .TP
 .B zenfs dump --zbd=nvme0n1
 Dump ZenFS filesystem metadata in JSON format.
+
+.TP
+.B zenfs fs-info --zbd=nvme0n1
+Prints the contents of the current ZenFS superblock.
 
 .SH AUTHOR
 .TP

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -539,6 +539,24 @@ int zenfs_tool_dump() {
   return 0;
 }
 
+int zenfs_tool_fsinfo() {
+  Status s;
+  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(true, false);
+  if (!zbd) return 1;
+
+  std::unique_ptr<ZenFS> zenFS;
+  s = zenfs_mount(zbd, &zenFS, true);
+  if (!s.ok()) {
+    fprintf(stderr, "Failed to mount filesystem, error: %s\n",
+            s.ToString().c_str());
+    return 1;
+  }
+  std::string superblock_report;
+  zenFS->ReportSuperblock(&superblock_report);
+  fprintf(stdout, "%s\n", superblock_report.c_str());
+  return 0;
+}
+
 }  // namespace ROCKSDB_NAMESPACE
 
 int main(int argc, char **argv) {
@@ -570,6 +588,8 @@ int main(int argc, char **argv) {
     return ROCKSDB_NAMESPACE::zenfs_tool_restore();
   } else if (subcmd == "dump") {
     return ROCKSDB_NAMESPACE::zenfs_tool_dump();
+  } else if (subcmd == "fs-info") {
+    return ROCKSDB_NAMESPACE::zenfs_tool_fsinfo();
   } else {
     fprintf(stderr, "Subcommand not recognized: %s\n", subcmd.c_str());
     return 1;

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,3 +1,10 @@
 zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
-zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/metrics.h fs/metrics_sample.h fs/snapshot.h
+zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/version.h fs/metrics.h fs/metrics_sample.h fs/snapshot.h
 zenfs_LDFLAGS = -lzbd -u zenfs_filesystem_reg
+
+ZENFS_ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+$(shell cd $(ZENFS_ROOT_DIR) && ./generate-version.sh)
+ifneq ($(.SHELLSTATUS),0)
+$(error Generating ZenFS version failed)
+endif


### PR DESCRIPTION
When building ZenFS through RocksDB the ZenFS version is updated by
its Makefile and contains the output of `git describe --dirty`.
This means that the version depends on the latest git tag and if
preceding commits exits the latest commit's short hash
(see (documentation)[https://git-scm.com/docs/git-describe]).

The version is regenerated if the git HEAD changed at build time.

Major, minor, patch, the short commit hash and a dirty flag is
persisted within the superblock. A new util command `fs-info` was
added that outputs the contents of the current superblock which
includes the ZenFS version information.

Suggested-by: Andreas Hindborg <andreas.hindborg@wdc.com>
Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>