### PR TITLE
fs: Correct impl of `ZenFS::DeleteFile` when target does not exist

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -417,6 +417,8 @@ IOStatus ZenFS::DeleteFile(std::string fname) {
     } else {
       zoneFile.reset();
     }
+  } else {
+    s = IOStatus::NotFound("ZenFS::DeleteFile(): File not found");
   }
   files_mtx_.unlock();
   return s;


### PR DESCRIPTION
Return error when trying to delete non existing file, to align with
`PosixFileSystem::DeleteFile()`:

```c++
    if (unlink(fname.c_str()) != 0) {
      result = IOError("while unlink() file", fname, errno);
    }
```