### PR TITLE
Add ZenFSMetrics to ZenFS

### DIFF
--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -6,7 +6,10 @@
 
 #pragma once
 
+#include <memory>
+
 #include "io_zenfs.h"
+#include "metrics.h"
 #include "rocksdb/env.h"
 #include "rocksdb/file_system.h"
 #include "rocksdb/status.h"
@@ -352,7 +355,9 @@ class ZenFS : public FileSystemWrapper {
 };
 #endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX)
 
-Status NewZenFS(FileSystem** fs, const std::string& bdevname);
+Status NewZenFS(
+    FileSystem** fs, const std::string& bdevname,
+    std::shared_ptr<ZenFSMetrics> metrics = std::make_shared<NoZenFSMetrics>());
 std::map<std::string, std::string> ListZenFileSystems();
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -252,6 +252,10 @@ ZoneExtent* ZoneFile::GetExtent(uint64_t file_offset, uint64_t* dev_offset) {
 
 IOStatus ZoneFile::PositionedRead(uint64_t offset, size_t n, Slice* result,
                                   char* scratch, bool direct) {
+  ZenFSMetricsLatencyGuard guard(zbd_->GetMetrics(), ZENFS_READ_LATENCY,
+                                 Env::Default());
+  zbd_->GetMetrics()->ReportQPS(ZENFS_READ_QPS, 1);
+
   int f = zbd_->GetReadFD();
   int f_direct = zbd_->GetReadDirectFD();
   char* ptr;

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -100,6 +100,7 @@ class ZoneFile {
  private:
   void ReleaseActiveZone();
   void SetActiveZone(Zone* zone);
+  std::shared_ptr<ZenFSMetrics> GetZBDMetrics() { return zbd_->GetMetrics(); }
 };
 
 class ZonedWritableFile : public FSWritableFile {

--- a/fs/metrics.h
+++ b/fs/metrics.h
@@ -1,0 +1,138 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+#include "rocksdb/env.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class ZenFSMetricsGuard;
+
+struct ZenFSMetrics {
+ public:
+  typedef uint32_t Label;
+  typedef uint32_t ReporterType;
+  // We give an enum to identify the reporters and an enum to identify the
+  // reporter types: ZenFSMetricsHistograms and ZenFSMetricsReporterType,
+  // respectively, at the end of the code.
+ public:
+  ZenFSMetrics() {}
+  virtual ~ZenFSMetrics() {}
+
+ public:
+  // Add a reporter named label.
+  // You can give a type for type-checking.
+  virtual void AddReporter(Label label, ReporterType type = 0) = 0;
+  // Report a value for the reporter named label.
+  // You can give a type for type-checking.
+  virtual void Report(Label label, size_t value,
+                      ReporterType type_check = 0) = 0;
+
+ public:
+  // Syntactic sugars for type-checking.
+  // Overwrite them if you think type-checking is necessary.
+  virtual void ReportQPS(Label label, size_t qps) { Report(label, qps, 0); }
+  virtual void ReportThroughput(Label label, size_t throughput) {
+    Report(label, throughput, 0);
+  }
+  virtual void ReportLatency(Label label, size_t latency) {
+    Report(label, latency, 0);
+  }
+  virtual void ReportGeneral(Label label, size_t data) {
+    Report(label, data, 0);
+  }
+  // and more
+};
+
+struct NoZenFSMetrics : public ZenFSMetrics {
+  NoZenFSMetrics() : ZenFSMetrics() {}
+  virtual ~NoZenFSMetrics() {}
+
+ public:
+  virtual void AddReporter(uint32_t label, uint32_t type = 0) override {}
+  virtual void Report(uint32_t label, size_t value,
+                      uint32_t type_check = 0) override {}
+};
+
+// The implementation of this class will start timing when initialized,
+// stop timing when it is destructured,
+// and report the difference in time to the target label via
+// metrics->ReportLatency(). By default, the method to collect the time will be
+// to call env->NowMicros().
+struct ZenFSMetricsLatencyGuard {
+  std::shared_ptr<ZenFSMetrics> metrics_;
+  uint32_t label_;
+  Env* env_;
+  uint64_t begin_time_micro_;
+
+  ZenFSMetricsLatencyGuard(std::shared_ptr<ZenFSMetrics> metrics,
+                           uint32_t label, Env* env)
+      : metrics_(metrics),
+        label_(label),
+        env_(env),
+        begin_time_micro_(GetTime()) {}
+
+  virtual ~ZenFSMetricsLatencyGuard() {
+    uint64_t end_time_micro_ = GetTime();
+    assert(end_time_micro_ >= begin_time_micro_);
+    metrics_->ReportLatency(label_,
+                            Report(end_time_micro_ - begin_time_micro_));
+  }
+  // overwrite this function if you wish to capture time by other methods.
+  virtual uint64_t GetTime() { return env_->NowMicros(); }
+  // overwrite this function if you do not intend to report delays measured in
+  // microseconds.
+  virtual uint64_t Report(uint64_t time) { return time; }
+};
+
+// Names of Reporter that may be used for statistics.
+enum ZenFSMetricsHistograms : uint32_t {
+  ZENFS_HISTOGRAM_ENUM_MIN,
+
+  ZENFS_FG_WRITE_LATENCY,
+  ZENFS_BG_WRITE_LATENCY,
+
+  ZENFS_READ_LATENCY,
+  ZENFS_FG_SYNC_LATENCY,
+  ZENFS_BG_SYNC_LATENCY,
+  ZENFS_IO_ALLOC_WAL_LATENCY,
+  ZENFS_IO_ALLOC_NON_WAL_LATENCY,
+  ZENFS_IO_ALLOC_WAL_ACTUAL_LATENCY,
+  ZENFS_IO_ALLOC_NON_WAL_ACTUAL_LATENCY,
+  ZENFS_META_ALLOC_LATENCY,
+  ZENFS_METADATA_SYNC_LATENCY,
+  ZENFS_ROLL_LATENCY,
+
+  ZENFS_WRITE_QPS,
+  ZENFS_READ_QPS,
+  ZENFS_SYNC_QPS,
+  ZENFS_IO_ALLOC_QPS,
+  ZENFS_META_ALLOC_QPS,
+  ZENFS_ROLL_QPS,
+
+  ZENFS_WRITE_THROUGHPUT,
+  ZENFS_ROLL_THROUGHPUT,
+
+  ZENFS_ACTIVE_ZONES,
+  ZENFS_OPEN_ZONES,
+  ZENFS_FREE_SPACE,
+  ZENFS_USED_SPACE,
+  ZENFS_RECLAIMABLE_SPACE,
+  ZENFS_RESETABLE_ZONES,
+
+  ZENFS_HISTOGRAM_ENUM_MAX,
+};
+
+// Types of Reporter that may be used for statistics.
+enum ZenFSMetricsReporterType : uint32_t {
+  ZENFS_REPORTER_TYPE_WITHOUT_CHECK = 0,
+  ZENFS_REPORTER_TYPE_GENERAL,
+  ZENFS_REPORTER_TYPE_LATENCY,
+  ZENFS_REPORTER_TYPE_QPS,
+  ZENFS_REPORTER_TYPE_THROUGHPUT
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/fs/metrics_sample.h
+++ b/fs/metrics_sample.h
@@ -1,0 +1,210 @@
+//  SPDX-License-Identifier: Apache License 2.0 OR GPL-2.0
+
+#include <iostream>
+#include <unordered_map>
+
+#include "metrics.h"
+#include "port/port.h"
+#include "util/mutexlock.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+const std::unordered_map<ZenFSMetricsHistograms, std::string>
+    ZenFSHistogramsNameMap = {
+        {ZENFS_FG_WRITE_LATENCY, "zenfs_fg_write_latency"},
+        {ZENFS_BG_WRITE_LATENCY, "zenfs_bg_write_latency"},
+        {ZENFS_READ_LATENCY, "zenfs_read_latency"},
+        {ZENFS_FG_SYNC_LATENCY, "fg_zenfs_sync_latency"},
+        {ZENFS_BG_SYNC_LATENCY, "bg_zenfs_sync_latency"},
+        {ZENFS_IO_ALLOC_WAL_LATENCY, "zenfs_io_alloc_wal_latency"},
+        {ZENFS_IO_ALLOC_NON_WAL_LATENCY, "zenfs_io_alloc_non_wal_latency"},
+        {ZENFS_IO_ALLOC_WAL_ACTUAL_LATENCY,
+         "zenfs_io_alloc_wal_actual_latency"},
+        {ZENFS_IO_ALLOC_NON_WAL_ACTUAL_LATENCY,
+         "zenfs_io_alloc_non_wal_actual_latency"},
+        {ZENFS_META_ALLOC_LATENCY, "rzenfs_meta_alloc_latency"},
+        {ZENFS_METADATA_SYNC_LATENCY, "zenfs_metadata_sync_latency"},
+        {ZENFS_ROLL_LATENCY, "zenfs_roll_latency"},
+        {ZENFS_WRITE_QPS, "zenfs_write_qps"},
+        {ZENFS_READ_QPS, "zenfs_read_qps"},
+        {ZENFS_SYNC_QPS, "zenfs_sync_qps"},
+        {ZENFS_IO_ALLOC_QPS, "zenfs_io_alloc_qps"},
+        {ZENFS_META_ALLOC_QPS, "zenfs_meta_alloc_qps"},
+        {ZENFS_ROLL_QPS, "zenfs_roll_qps"},
+        {ZENFS_WRITE_THROUGHPUT, "rzenfs_write_throughput"},
+        {ZENFS_ROLL_THROUGHPUT, "zenfs_roll_throughput"},
+        {ZENFS_ACTIVE_ZONES, "zenfs_active_zones"},
+        {ZENFS_OPEN_ZONES, "zenfs_open_zones"},
+        {ZENFS_FREE_SPACE, "zenfs_free_space"},
+        {ZENFS_USED_SPACE, "zenfs_used_space"},
+        {ZENFS_RECLAIMABLE_SPACE, "zenfs_reclaimable_space"},
+        {ZENFS_RESETABLE_ZONES, "zenfs_resetable_zones"}};
+
+const std::unordered_map<ZenFSMetricsHistograms, ZenFSMetricsReporterType>
+    ZenFSHistogramsTypeMap = {
+        {ZENFS_FG_WRITE_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_BG_WRITE_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_READ_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_FG_SYNC_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_BG_SYNC_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_IO_ALLOC_WAL_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_IO_ALLOC_NON_WAL_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_IO_ALLOC_WAL_ACTUAL_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_IO_ALLOC_NON_WAL_ACTUAL_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_META_ALLOC_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_METADATA_SYNC_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_ROLL_LATENCY, ZENFS_REPORTER_TYPE_LATENCY},
+        {ZENFS_WRITE_QPS, ZENFS_REPORTER_TYPE_QPS},
+        {ZENFS_READ_QPS, ZENFS_REPORTER_TYPE_QPS},
+        {ZENFS_SYNC_QPS, ZENFS_REPORTER_TYPE_QPS},
+        {ZENFS_IO_ALLOC_QPS, ZENFS_REPORTER_TYPE_QPS},
+        {ZENFS_META_ALLOC_QPS, ZENFS_REPORTER_TYPE_QPS},
+        {ZENFS_ROLL_QPS, ZENFS_REPORTER_TYPE_QPS},
+        {ZENFS_WRITE_THROUGHPUT, ZENFS_REPORTER_TYPE_THROUGHPUT},
+        {ZENFS_ROLL_THROUGHPUT, ZENFS_REPORTER_TYPE_THROUGHPUT},
+        {ZENFS_ACTIVE_ZONES, ZENFS_REPORTER_TYPE_GENERAL},
+        {ZENFS_OPEN_ZONES, ZENFS_REPORTER_TYPE_GENERAL},
+        {ZENFS_FREE_SPACE, ZENFS_REPORTER_TYPE_GENERAL},
+        {ZENFS_USED_SPACE, ZENFS_REPORTER_TYPE_GENERAL},
+        {ZENFS_RECLAIMABLE_SPACE, ZENFS_REPORTER_TYPE_GENERAL},
+        {ZENFS_RESETABLE_ZONES, ZENFS_REPORTER_TYPE_GENERAL}};
+
+struct ReporterSample {
+ public:
+  typedef uint64_t TypeTime;
+  typedef uint64_t TypeValue;
+  typedef std::pair<TypeTime, TypeValue> TypeRecord;
+
+ private:
+  port::Mutex mu_;
+  ZenFSMetricsReporterType type_;
+  std::vector<TypeRecord> hist_;
+
+  static const TypeTime MinReportInterval =
+      30 * 1000000;  // 30 seconds for all reporters by default.
+  bool ReadyToReport(uint64_t time) const {
+    // AssertHeld(&mu);
+    if (hist_.size() == 0) return 1;
+    TypeTime last_report_time = hist_.rbegin()->first;
+    return time > last_report_time + MinReportInterval;
+  }
+
+ public:
+  ReporterSample(ZenFSMetricsReporterType type) : mu_(), type_(type), hist_() {}
+  void Record(const TypeTime& time, TypeValue value) {
+    MutexLock guard(&mu_);
+    if (ReadyToReport(time)) hist_.push_back(TypeRecord(time, value));
+  }
+  ZenFSMetricsReporterType Type() const { return type_; }
+  void GetHistSnapshot(std::vector<TypeRecord>& hist) {
+    MutexLock guard(&mu_);
+    hist = hist_;
+  }
+};
+
+struct ZenFSMetricsSample : public ZenFSMetrics {
+ public:
+  typedef uint64_t TypeMicroSec;
+  typedef ReporterSample TypeReporter;
+
+ private:
+  Env* env_;
+  std::unordered_map<ZenFSMetricsHistograms, TypeReporter> reporter_map_;
+
+ public:
+  ZenFSMetricsSample(Env* env) : env_(env), reporter_map_() {
+    for (auto& label_with_type : ZenFSHistogramsTypeMap)
+      AddReporter(static_cast<uint32_t>(label_with_type.first),
+                  static_cast<uint32_t>(label_with_type.second));
+  }
+  ~ZenFSMetricsSample() {}
+
+  virtual void AddReporter(uint32_t label_uint,
+                           uint32_t type_uint = 0) override {
+    auto label = static_cast<ZenFSMetricsHistograms>(label_uint);
+    assert(ZenFSHistogramsNameMap.find(label) !=
+           ZenFSHistogramsNameMap.end());
+    auto type = ZenFSHistogramsTypeMap.find(label)->second;
+
+    if (type_uint != 0) {
+      auto type_check = static_cast<ZenFSMetricsReporterType>(type_uint);
+      assert(type_check == type);
+    }
+
+    switch (type) {
+      case ZENFS_REPORTER_TYPE_GENERAL:
+      case ZENFS_REPORTER_TYPE_LATENCY:
+      case ZENFS_REPORTER_TYPE_QPS:
+      case ZENFS_REPORTER_TYPE_THROUGHPUT:
+      case ZENFS_REPORTER_TYPE_WITHOUT_CHECK: {
+        reporter_map_.emplace(label, type);
+      } break;
+    }
+  }
+  virtual void Report(uint32_t label_uint, size_t value,
+                      uint32_t type_uint = 0) override {
+    auto label = static_cast<ZenFSMetricsHistograms>(label_uint);
+    assert(ZenFSHistogramsNameMap.find(label) !=
+           ZenFSHistogramsNameMap.end());
+    auto p = reporter_map_.find(static_cast<ZenFSMetricsHistograms>(label));
+    assert(p != reporter_map_.end());
+    TypeReporter& reporter = p->second;
+    auto type = reporter.Type();
+
+    if (type_uint != 0) {
+      auto type_check = static_cast<ZenFSMetricsReporterType>(type_uint);
+      assert(type_check == type);
+    }
+
+    switch (type) {
+      case ZENFS_REPORTER_TYPE_GENERAL:
+      case ZENFS_REPORTER_TYPE_LATENCY:
+      case ZENFS_REPORTER_TYPE_QPS:
+      case ZENFS_REPORTER_TYPE_THROUGHPUT:
+      case ZENFS_REPORTER_TYPE_WITHOUT_CHECK: {
+        reporter.Record(GetTime(), value);
+      } break;
+    }
+  }
+
+ public:
+  virtual void ReportQPS(uint32_t label, size_t qps) override {
+    Report(label, qps, ZENFS_REPORTER_TYPE_QPS);
+  }
+  virtual void ReportLatency(uint32_t label, size_t latency) override {
+    Report(label, latency, ZENFS_REPORTER_TYPE_LATENCY);
+  }
+  virtual void ReportThroughput(uint32_t label, size_t throughput) override {
+    Report(label, throughput, ZENFS_REPORTER_TYPE_THROUGHPUT);
+  }
+  virtual void ReportGeneral(uint32_t label, size_t value) override {
+    Report(label, value, ZENFS_REPORTER_TYPE_GENERAL);
+  }
+
+ public:
+  virtual void DebugPrint(std::ostream& os) {
+    os << "[Text histogram from ZenFSMetricsSample: ]{" << std::endl;
+    for (auto& label_with_rep : reporter_map_) {
+      auto label = label_with_rep.first;
+      auto& reporter = label_with_rep.second;
+      const std::string& name = ZenFSHistogramsNameMap.find(label)->second;
+      os << "  " << name << ":[";
+
+      std::vector<std::pair<uint64_t, uint64_t>> hist;
+      reporter.GetHistSnapshot(hist);
+      for (auto& time_with_value : hist) {
+        auto time = time_with_value.first;
+        auto value = time_with_value.second;
+        os << "(" << time << "," << value << "),";
+      }
+
+      os << "]" << std::endl;
+    }
+    os << "}[End Histogram.]" << std::endl;
+  }
+
+ private:
+  uint64_t GetTime() { return env_->NowMicros(); }
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "metrics.h"
 #include "rocksdb/env.h"
 #include "rocksdb/io_status.h"
 
@@ -94,12 +95,16 @@ class ZonedBlockDevice {
   unsigned int max_nr_active_io_zones_;
   unsigned int max_nr_open_io_zones_;
 
+  std::shared_ptr<ZenFSMetrics> metrics_;
+
   void EncodeJsonZone(std::ostream &json_stream,
                       const std::vector<Zone *> zones);
 
  public:
   explicit ZonedBlockDevice(std::string bdevname,
-                            std::shared_ptr<Logger> logger);
+                            std::shared_ptr<Logger> logger,
+                            std::shared_ptr<ZenFSMetrics> metrics =
+                                std::make_shared<NoZenFSMetrics>());
   virtual ~ZonedBlockDevice();
 
   IOStatus Open(bool readonly, bool exclusive);
@@ -137,6 +142,8 @@ class ZonedBlockDevice {
   void EncodeJson(std::ostream &json_stream);
 
   std::mutex zone_resources_mtx_; /* Protects active/open io zones */
+
+  std::shared_ptr<ZenFSMetrics> GetMetrics() { return metrics_; }
 
  private:
   std::string ErrorToString(int err);

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,3 +1,3 @@
 zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
-zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h
+zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/metrics.h fs/metrics_sample.h
 zenfs_LDFLAGS = -lzbd -u zenfs_filesystem_reg


### PR DESCRIPTION
ZenFSMetrics is used to monitor some of the variables on ZenFS in real time.
In addition to this, two other classes have been added to metrics.h.
NoZenFSMetrics is an empty implementation of ZenFSMetrics and is used by default.
ZenFSMetricsLatencyGuard is used to count the execution time of a function, and it reports the time between construction and destruction to Metrics.