### PR TITLE
add Metrics patch

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -232,7 +232,7 @@ void ZenFS::LogFiles() {
          zFile->GetFileSize(), zFile->GetWriteLifeTimeHint());
     for (unsigned int i = 0; i < extents.size(); i++) {
       ZoneExtent* extent = extents[i];
-      Info(logger_, "          Extent %u {start=0x%lx, zone=%u, len=%u} ", i,
+      Info(logger_, "          Extent %u {start=0x%lx, zone=%u, len=%lu} ", i,
            extent->start_,
            (uint32_t)(extent->zone_->start_ / zbd_->GetZoneSize()),
            extent->length_);

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -32,7 +32,7 @@ class Superblock {
  public:
   const uint32_t MAGIC = 0x5a454e46; /* ZENF */
   const uint32_t ENCODED_SIZE = 512;
-  const uint32_t CURRENT_VERSION = 1;
+  const uint32_t CURRENT_VERSION = 2;
   const uint32_t DEFAULT_FLAGS = 0;
 
   Superblock() {}

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -28,7 +28,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-ZoneExtent::ZoneExtent(uint64_t start, uint32_t length, Zone* zone)
+ZoneExtent::ZoneExtent(uint64_t start, uint64_t length, Zone* zone)
     : start_(start), length_(length), zone_(zone) {}
 
 Status ZoneExtent::DecodeFrom(Slice* input) {
@@ -36,13 +36,13 @@ Status ZoneExtent::DecodeFrom(Slice* input) {
     return Status::Corruption("ZoneExtent", "Error: length missmatch");
 
   GetFixed64(input, &start_);
-  GetFixed32(input, &length_);
+  GetFixed64(input, &length_);
   return Status::OK();
 }
 
 void ZoneExtent::EncodeTo(std::string* output) {
   PutFixed64(output, start_);
-  PutFixed32(output, length_);
+  PutFixed64(output, length_);
 }
 
 void ZoneExtent::EncodeJson(std::ostream& json_stream) {

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -249,6 +249,9 @@ ZoneExtent* ZoneFile::GetExtent(uint64_t file_offset, uint64_t* dev_offset) {
 
 IOStatus ZoneFile::PositionedRead(uint64_t offset, size_t n, Slice* result,
                                   char* scratch, bool direct) {
+  ZenFSMetricsLatencyGuard guard(zbd_->GetMetrics(), ZENFS_READ_LATENCY, Env::Default());
+  zbd_->GetMetrics()->ReportQPS(ZENFS_READ_QPS, 1);
+  
   int f = zbd_->GetReadFD();
   int f_direct = zbd_->GetReadDirectFD();
   char* ptr;

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -96,6 +96,8 @@ class ZoneFile {
 
   uint64_t GetID() { return file_id_; }
   size_t GetUniqueId(char* id, size_t max_size);
+
+  std::shared_ptr<ZenFSMetrics> GetZBDMetrics() { return zbd_->GetMetrics(); }
 };
 
 class ZonedWritableFile : public FSWritableFile {

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -29,10 +29,10 @@ namespace ROCKSDB_NAMESPACE {
 class ZoneExtent {
  public:
   uint64_t start_;
-  uint32_t length_;
+  uint64_t length_;
   Zone* zone_;
 
-  explicit ZoneExtent(uint64_t start, uint32_t length, Zone* zone);
+  explicit ZoneExtent(uint64_t start, uint64_t length, Zone* zone);
   Status DecodeFrom(Slice* input);
   void EncodeTo(std::string* output);
   void EncodeJson(std::ostream& json_stream);

--- a/fs/metrics.h
+++ b/fs/metrics.h
@@ -1,0 +1,111 @@
+#pragma once
+#include "rocksdb/env.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+struct ZenFSMetrics {
+public:
+  typedef uint32_t Label;
+  typedef uint32_t ReporterType;
+  // We give an enum to identify the reporters and an enum to identify the reporter types: 
+  // ZenFSMetricsHistograms and ZenFSMetricsReporterType, respectively, at the end of the code.
+public:
+  ZenFSMetrics() {}
+  virtual ~ZenFSMetrics() {}
+public:
+  // Add a reporter named label.
+  // You can give a type for type-checking.
+  virtual void AddReporter(Label label, ReporterType type = 0) = 0;
+  // Report a value for the reporter named label.
+  // You can give a type for type-checking.
+  virtual void Report(Label label, size_t value, ReporterType type_check = 0) = 0;
+public: 
+  // Syntactic sugars for type-checking.
+  // Overwrite them if you think type-checking is necessary.
+  virtual void ReportQPS(Label label, size_t qps) { Report(label, qps, 0); }
+  virtual void ReportThroughput(Label label, size_t throughput) { Report(label, throughput, 0); }
+  virtual void ReportLatency(Label label, size_t latency) { Report(label, latency, 0); }
+  virtual void ReportGeneral(Label label, size_t data) { Report(label, data, 0); }
+  // and more
+};
+
+struct NoZenFSMetrics : public ZenFSMetrics {
+  NoZenFSMetrics() : ZenFSMetrics() {}
+  virtual ~NoZenFSMetrics() {}
+public:
+  virtual void AddReporter(uint32_t label, uint32_t type = 0) override {}
+  virtual void Report(uint32_t label, size_t value, uint32_t type_check = 0) override {}
+};
+
+// The implementation of this class will start timing when initialized, 
+// stop timing when it is destructured, 
+// and report the difference in time to the target label via metrics->ReportLatency().
+// By default, the method to collect the time will be to call env->NowMicros().
+struct ZenFSMetricsLatencyGuard {
+  std::shared_ptr<ZenFSMetrics> metrics_;
+  uint32_t label_;
+  Env* env_;
+  uint64_t begin_time_micro_;
+
+  ZenFSMetricsLatencyGuard(std::shared_ptr<ZenFSMetrics> metrics, uint32_t label, Env* env)
+  : metrics_(metrics), label_(label), env_(env), begin_time_micro_(GetTime()) {}
+
+  virtual ~ZenFSMetricsLatencyGuard() {
+    uint64_t end_time_micro_ = GetTime();
+    assert(end_time_micro_ >= begin_time_micro_);
+    metrics_->ReportLatency(label_, Report(end_time_micro_ - begin_time_micro_)); 
+  }
+  // overwrite this function if you wish to capture time by other methods.
+  virtual uint64_t GetTime() { return env_->NowMicros(); }
+  // overwrite this function if you do not intend to report delays measured in microseconds.
+  virtual uint64_t Report(uint64_t time) { return time; }
+};
+
+// Names of Reporter that may be used for statistics.
+enum ZenFSMetricsHistograms : uint32_t {
+  ZENFS_HISTOGRAM_ENUM_MIN, 
+
+  ZENFS_FG_WRITE_LATENCY,
+  ZENFS_BG_WRITE_LATENCY,
+  
+  ZENFS_READ_LATENCY,
+  ZENFS_FG_SYNC_LATENCY,
+  ZENFS_BG_SYNC_LATENCY,
+  ZENFS_IO_ALLOC_WAL_LATENCY,
+  ZENFS_IO_ALLOC_NON_WAL_LATENCY,
+  ZENFS_IO_ALLOC_WAL_ACTUAL_LATENCY,
+  ZENFS_IO_ALLOC_NON_WAL_ACTUAL_LATENCY,
+  ZENFS_META_ALLOC_LATENCY,
+  ZENFS_METADATA_SYNC_LATENCY,
+  ZENFS_ROLL_LATENCY,
+
+  ZENFS_WRITE_QPS,
+  ZENFS_READ_QPS,
+  ZENFS_SYNC_QPS,
+  ZENFS_IO_ALLOC_QPS,
+  ZENFS_META_ALLOC_QPS,
+  ZENFS_ROLL_QPS,
+
+  ZENFS_WRITE_THROUGHPUT,
+  ZENFS_ROLL_THROUGHPUT,
+  
+  ZENFS_ACTIVE_ZONES,
+  ZENFS_OPEN_ZONES,
+  ZENFS_FREE_SPACE,
+  ZENFS_USED_SPACE,
+  ZENFS_RECLAIMABLE_SPACE,
+  ZENFS_RESETABLE_ZONES,
+
+  ZENFS_HISTOGRAM_ENUM_MAX,
+};
+
+// Types of Reporter that may be used for statistics.
+enum ZenFSMetricsReporterType : uint32_t {
+  ZENFS_REPORTER_TYPE_WITHOUT_CHECK = 0,
+  ZENFS_REPORTER_TYPE_GENERAL,
+  ZENFS_REPORTER_TYPE_LATENCY,    
+  ZENFS_REPORTER_TYPE_QPS,
+  ZENFS_REPORTER_TYPE_THROUGHPUT
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -174,7 +174,8 @@ Zone *ZonedBlockDevice::GetIOZone(uint64_t offset) {
 
 ZonedBlockDevice::ZonedBlockDevice(std::string bdevname,
                                    std::shared_ptr<Logger> logger)
-    : filename_("/dev/" + bdevname), logger_(logger) {
+    : filename_("/dev/" + bdevname), logger_(logger),
+      metrics_(std::make_shared<NoZenFSMetrics>()) {
   Info(logger_, "New Zoned Block Device: %s", filename_.c_str());
 };
 
@@ -441,6 +442,9 @@ unsigned int GetLifeTimeDiff(Env::WriteLifeTimeHint zone_lifetime,
 }
 
 Zone *ZonedBlockDevice::AllocateMetaZone() {
+  ZenFSMetricsLatencyGuard guard(metrics_, ZENFS_META_ALLOC_LATENCY, Env::Default());
+  metrics_->ReportQPS(ZENFS_META_ALLOC_QPS, 1);
+
   for (const auto z : meta_zones) {
     /* If the zone is not used, reset and use it */
     if (!z->IsUsed()) {
@@ -473,6 +477,9 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime) {
   unsigned int best_diff = LIFETIME_DIFF_NOT_GOOD;
   int new_zone = 0;
   Status s;
+
+  ZenFSMetricsLatencyGuard guard(metrics_, ZENFS_IO_ALLOC_NON_WAL_LATENCY, Env::Default());
+  metrics_->ReportQPS(ZENFS_IO_ALLOC_QPS, 1);
 
   io_zones_mtx.lock();
 
@@ -567,6 +574,9 @@ Zone *ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime) {
 
   io_zones_mtx.unlock();
   LogZoneStats();
+
+  metrics_->ReportGeneral(ZENFS_OPEN_ZONES, open_io_zones_);
+  metrics_->ReportGeneral(ZENFS_ACTIVE_ZONES, active_io_zones_);
 
   return allocated_zone;
 }

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -26,6 +26,8 @@
 #include "rocksdb/env.h"
 #include "rocksdb/io_status.h"
 
+#include "metrics.h"
+
 namespace ROCKSDB_NAMESPACE {
 
 class ZonedBlockDevice;
@@ -83,6 +85,8 @@ class ZonedBlockDevice {
   unsigned int max_nr_active_io_zones_;
   unsigned int max_nr_open_io_zones_;
 
+  std::shared_ptr<ZenFSMetrics> metrics_;
+
   void EncodeJsonZone(std::ostream &json_stream,
                       const std::vector<Zone *> zones);
 
@@ -126,6 +130,9 @@ class ZonedBlockDevice {
   void EncodeJson(std::ostream &json_stream);
 
   std::mutex zone_resources_mtx_; /* Protects active/open io zones */
+
+  void SetMetrics(std::shared_ptr<ZenFSMetrics> metrics) { metrics_ = metrics; }
+  std::shared_ptr<ZenFSMetrics> GetMetrics() { return metrics_; }
 
  private:
   std::string ErrorToString(int err);

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,3 +1,3 @@
 zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
-zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h
+zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/metrics.h
 zenfs_LDFLAGS = -lzbd -u zenfs_filesystem_reg


### PR DESCRIPTION
I added ZenFSMetrics to the for_v2 branch.

ZenFSMetrics is used to monitor some of the variables on ZenFS in real time.
In addition to this, two other classes have been added to metrics.h.
NoZenFSMetrics is an empty implementation of ZenFSMetrics and is used by default.
ZenFSMetricsLatencyGuard is used to count the execution time of a function, 
and it reports the time between construction and destruction to Metrics.