### PR TITLE
fs: A patch adding GetSnapshot() into zenfs.

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -20,6 +20,7 @@
 
 #include "metrics_sample.h"
 #include "rocksdb/utilities/object_registry.h"
+#include "snapshot.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
 
@@ -1169,6 +1170,17 @@ std::map<std::string, std::string> ListZenFileSystems() {
   }
 
   return zenFileSystems;
+}
+
+void ZenFS::GetZoneSnapshot(std::vector<ZoneSnapshot>& zones) {
+  zbd_->GetZoneSnapshot(zones);
+}
+
+void ZenFS::GetZoneFileSnapshot(std::vector<ZoneFileSnapshot>& zone_files) {
+  std::lock_guard<std::mutex> file_lock(files_mtx_);
+  for (auto& file_it : files_) {
+    zone_files.emplace_back(*file_it.second);
+  }
 }
 
 extern "C" FactoryFunc<FileSystem> zenfs_filesystem_reg;

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -19,6 +19,9 @@ namespace ROCKSDB_NAMESPACE {
 
 #if !defined(ROCKSDB_LITE) && defined(OS_LINUX)
 
+class ZoneSnapshot;
+class ZoneFileSnapshot;
+
 class Superblock {
   uint32_t magic_ = 0;
   char uuid_[37] = {0};
@@ -353,6 +356,8 @@ class ZenFS : public FileSystemWrapper {
                                 IODebugContext* /*dbg*/) override {
     return IOStatus::NotSupported("AreFilesSame is not supported in ZenFS");
   }
+  void GetZoneSnapshot(std::vector<ZoneSnapshot>& zones);
+  void GetZoneFileSnapshot(std::vector<ZoneFileSnapshot>& zone_files);
 };
 #endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX)
 

--- a/fs/snapshot.h
+++ b/fs/snapshot.h
@@ -1,0 +1,78 @@
+// Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+// Copyright (c) 2019-present, Western Digital Corporation
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "io_zenfs.h"
+#include "zbd_zenfs.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+// These are three Snapshot classes to capture real-time information from ZenFS
+// for use by the upper layer algorithms. The three Snapshots will capture
+// information from Zone, ZoneFile, and ZoneExtent respectively. If you plan to
+// modify the variables of these three classes, please make sure that they have
+// a public interface for copying and that the interface of the Snapshot classes
+// are still logically correct after modification.
+
+class ZoneSnapshot {
+ private:
+  uint64_t start_;
+  uint64_t capacity_;
+  uint64_t max_capacity_;
+  uint64_t wp_;
+
+ public:
+  ZoneSnapshot(const Zone& zone)
+      : start_(zone.start_),
+        capacity_(zone.capacity_),
+        max_capacity_(zone.max_capacity_),
+        wp_(zone.wp_) {}
+
+  uint64_t ID() const { return start_; }
+  uint64_t RemainingCapacity() const { return capacity_; }
+  uint64_t MaxCapacity() const { return max_capacity_; }
+  uint64_t StartPosition() const { return start_; }
+  uint64_t WritePosition() const { return wp_; }
+};
+
+struct ZoneExtentSnapshot {
+ private:
+  uint64_t start_;
+  uint64_t length_;
+  uint64_t zone_start_;
+
+ public:
+  ZoneExtentSnapshot(const ZoneExtent& extent)
+      : start_(extent.start_),
+        length_(extent.length_),
+        zone_start_(extent.zone_->start_) {}
+
+  uint64_t Start() const { return start_; }
+  uint64_t Length() const { return length_; }
+  uint64_t ZoneID() const { return zone_start_; }
+};
+
+struct ZoneFileSnapshot {
+ private:
+  uint64_t file_id_;
+  std::string filename_;
+  std::vector<ZoneExtentSnapshot> extent_;
+
+ public:
+  ZoneFileSnapshot(ZoneFile& file)
+      : file_id_(file.GetID()), filename_(file.GetFilename()), extent_() {
+    for (ZoneExtent*& extent : file.GetExtents()) extent_.emplace_back(*extent);
+  }
+
+  uint64_t FileID() const { return file_id_; }
+  const std::string& Filename() const { return filename_; }
+  const std::vector<ZoneExtentSnapshot>& Extent() const { return extent_; }
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -7,6 +7,7 @@
 #if !defined(ROCKSDB_LITE) && !defined(OS_WIN)
 
 #include "zbd_zenfs.h"
+#include "snapshot.h"
 
 #include <assert.h>
 #include <errno.h>
@@ -721,6 +722,10 @@ void ZonedBlockDevice::SetZoneDeferredStatus(IOStatus status) {
   if (!zone_deferred_status_.ok()) {
     zone_deferred_status_ = status;
   }
+}
+
+void ZonedBlockDevice::GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot) {
+  for (auto &zone : io_zones) snapshot.emplace_back(*zone);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -30,6 +30,7 @@
 namespace ROCKSDB_NAMESPACE {
 
 class ZonedBlockDevice;
+class ZoneSnapshot;
 
 class Zone {
   ZonedBlockDevice *zbd_;
@@ -151,6 +152,8 @@ class ZonedBlockDevice {
   void SetZoneDeferredStatus(IOStatus status);
 
   std::shared_ptr<ZenFSMetrics> GetMetrics() { return metrics_; }
+
+  void GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot);
 
  private:
   std::string ErrorToString(int err);

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,3 +1,3 @@
 zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
-zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/metrics.h fs/metrics_sample.h
+zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/metrics.h fs/metrics_sample.h fs/snapshot.h
 zenfs_LDFLAGS = -lzbd -u zenfs_filesystem_reg


### PR DESCRIPTION
These are snapshot classes to capture real-time information from ZenFS
for use by the upper layer algorithms. The three snapshots will capture
information from Zone, ZoneFile, and ZoneExtent respectively.
There are new methods in ZoneBlockDevice and ZenFS to get snapshots of ZenFS.

_There is a new Patch being used to support more flexible Snapshot fetching, 
passing in an Option to get a subset of the ZenFS parameters instead of all of them._
Removed (may be a future PR:)

Signed-off-by: Liu Ruicheng <sagitrs67@gmail.com>
Signed-off-by: Alex Chi <iskyzh@gmail.com>