### PR TITLE
fs: Add support for getting ZBD status.

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -282,9 +282,9 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   Zone* new_meta_zone = nullptr;
   IOStatus s;
 
-  ZenFSMetricsLatencyGuard guard(zbd_->GetMetrics(), ZENFS_ROLL_LATENCY,
+  ZenFSMetricsLatencyGuard guard(zbd_->GetMetrics(), ZENFS_LABEL(ROLL, LATENCY),
                                  Env::Default());
-  zbd_->GetMetrics()->ReportQPS(ZENFS_ROLL_QPS, 1);
+  zbd_->GetMetrics()->ReportQPS(ZENFS_LABEL(ROLL, QPS), 1);
 
   IOStatus status = zbd_->AllocateMetaZone(&new_meta_zone);
   if (!status.ok()) return status;
@@ -364,8 +364,8 @@ IOStatus ZenFS::SyncFileMetadata(std::shared_ptr<ZoneFile> zoneFile) {
   std::string fileRecord;
   std::string output;
   IOStatus s;
-  ZenFSMetricsLatencyGuard guard(zbd_->GetMetrics(),
-                                 ZENFS_METADATA_SYNC_LATENCY, Env::Default());
+  ZenFSMetricsLatencyGuard guard(
+      zbd_->GetMetrics(), ZENFS_LABEL(META_SYNC, LATENCY), Env::Default());
   std::lock_guard<std::mutex> lock(files_mtx_);
   zoneFile->SetFileModificationTime(time(0));
   PutFixed32(&output, kFileUpdate);
@@ -1171,16 +1171,31 @@ std::map<std::string, std::string> ListZenFileSystems() {
 
   return zenFileSystems;
 }
-
 void ZenFS::GetZoneSnapshot(std::vector<ZoneSnapshot>& zones) {
-  zbd_->GetZoneSnapshot(zones);
+  ZenFSSnapshotOptions options;
+  if (options.zone_.enabled_) zbd_->GetZoneSnapshot(zones, options);
 }
-
 void ZenFS::GetZoneFileSnapshot(std::vector<ZoneFileSnapshot>& zone_files) {
-  std::lock_guard<std::mutex> file_lock(files_mtx_);
-  for (auto& file_it : files_) {
-    zone_files.emplace_back(*file_it.second);
+  ZenFSSnapshotOptions options;
+  if (options.zone_file_.enabled_) {
+    std::lock_guard<std::mutex> file_lock(files_mtx_);
+    for (auto& file_it : files_)
+      zone_files.emplace_back(*file_it.second, options);
   }
+}
+void ZenFS::GetZenFSSnapshot(ZenFSSnapshot& snapshot,
+                             const ZenFSSnapshotOptions& options) {
+  if (options.zbd_.enabled_) {
+    snapshot.zbd_ = ZBDSnapshot(*zbd_, options);
+  }
+  if (options.zone_.enabled_) zbd_->GetZoneSnapshot(snapshot.zones_, options);
+  if (options.zone_file_.enabled_) {
+    std::lock_guard<std::mutex> file_lock(files_mtx_);
+    for (auto& file_it : files_)
+      snapshot.zone_files_.emplace_back(*file_it.second, options);
+  }
+  if (options.trigger_report_)
+    zbd_->GetMetrics()->ReportSnapshot(snapshot, options);
 }
 
 extern "C" FactoryFunc<FileSystem> zenfs_filesystem_reg;

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -21,6 +21,8 @@ namespace ROCKSDB_NAMESPACE {
 
 class ZoneSnapshot;
 class ZoneFileSnapshot;
+class ZenFSSnapshot;
+class ZenFSSnapshotOptions;
 
 class Superblock {
   uint32_t magic_ = 0;
@@ -356,8 +358,11 @@ class ZenFS : public FileSystemWrapper {
                                 IODebugContext* /*dbg*/) override {
     return IOStatus::NotSupported("AreFilesSame is not supported in ZenFS");
   }
+
   void GetZoneSnapshot(std::vector<ZoneSnapshot>& zones);
   void GetZoneFileSnapshot(std::vector<ZoneFileSnapshot>& zone_files);
+  void GetZenFSSnapshot(ZenFSSnapshot& snapshot,
+                        const ZenFSSnapshotOptions& options);
 };
 #endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX)
 

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -103,7 +103,10 @@ class ZoneFile {
   void ReleaseActiveZone();
   void SetActiveZone(Zone* zone);
   IOStatus CloseActiveZone();
+
+ public:
   std::shared_ptr<ZenFSMetrics> GetZBDMetrics() { return zbd_->GetMetrics(); }
+  IOType GetIOType() const { return IOType::kUnknown; }
 };
 
 class ZonedWritableFile : public FSWritableFile {

--- a/fs/snapshot.h
+++ b/fs/snapshot.h
@@ -20,6 +20,59 @@ namespace ROCKSDB_NAMESPACE {
 // modify the variables of these three classes, please make sure that they have
 // a public interface for copying and that the interface of the Snapshot classes
 // are still logically correct after modification.
+struct ZenFSSnapshotOptions {
+  struct ZBDSnapshotOptions {
+    bool enabled_ = 1;
+    bool get_free_space_ = 1;
+    bool get_used_space_ = 1;
+    bool get_reclaimable_space_ = 1;
+  } zbd_;
+  struct ZoneSnapshotOptions {
+    bool enabled_ = 1;
+    bool id_ = 1;
+    bool remaining_capacity_ = 1;
+    bool max_capacity_ = 1;
+    bool write_position_ = 1;
+    bool start_position_ = 1;
+  } zone_;
+  struct ZoneFileSnapshotOptions {
+    bool enabled_ = 1;
+    bool id_ = 1;
+    bool filename_ = 1;
+  } zone_file_;
+  struct ZoneExtentSnapshotOptions {
+    bool enabled_ = 1;
+    bool start_ = 1;
+    bool length_ = 1;
+    bool zone_id_ = 1;
+  } zone_extent_;
+
+  bool trigger_report_ = 1;
+
+  bool as_lock_free_as_possible_ = 1;
+};
+class ZBDSnapshot {
+ private:
+  uint64_t free_space_;
+  uint64_t used_space_;
+  uint64_t reclaimable_space_;
+
+ public:
+  ZBDSnapshot() = default;
+  ZBDSnapshot(const ZBDSnapshot&) = default;
+  ZBDSnapshot(ZonedBlockDevice& zbd, const ZenFSSnapshotOptions& options)
+      : free_space_(), used_space_(), reclaimable_space_() {
+    if (options.zbd_.enabled_) {
+      if (options.zbd_.get_free_space_) free_space_ = zbd.GetFreeSpace();
+      if (options.zbd_.get_used_space_) used_space_ = zbd.GetUsedSpace();
+      if (options.zbd_.get_reclaimable_space_)
+        reclaimable_space_ = zbd.GetReclaimableSpace();
+    }
+  }
+  uint64_t GetFreeSpace() const { return free_space_; }
+  uint64_t GetUsedSpace() const { return used_space_; }
+  uint64_t GetReclaimableSpace() const { return reclaimable_space_; }
+};
 
 class ZoneSnapshot {
  private:
@@ -29,11 +82,14 @@ class ZoneSnapshot {
   uint64_t wp_;
 
  public:
-  ZoneSnapshot(const Zone& zone)
-      : start_(zone.start_),
-        capacity_(zone.capacity_),
-        max_capacity_(zone.max_capacity_),
-        wp_(zone.wp_) {}
+  ZoneSnapshot(const Zone& zone, const ZenFSSnapshotOptions& options)
+      : start_(), capacity_(), max_capacity_(), wp_() {
+    if (options.zone_.enabled_) {
+      if (options.zone_.id_ || options.zone_.write_position_) wp_ = zone.wp_;
+      if (options.zone_.remaining_capacity_) capacity_ = zone.capacity_;
+      if (options.zone_.max_capacity_) max_capacity_ = zone.max_capacity_;
+    }
+  }
 
   uint64_t ID() const { return start_; }
   uint64_t RemainingCapacity() const { return capacity_; }
@@ -49,10 +105,15 @@ struct ZoneExtentSnapshot {
   uint64_t zone_start_;
 
  public:
-  ZoneExtentSnapshot(const ZoneExtent& extent)
-      : start_(extent.start_),
-        length_(extent.length_),
-        zone_start_(extent.zone_->start_) {}
+  ZoneExtentSnapshot(const ZoneExtent& extent,
+                     const ZenFSSnapshotOptions& options)
+      : start_(), length_(), zone_start_() {
+    if (options.zone_extent_.enabled_) {
+      if (options.zone_extent_.start_) start_ = extent.start_;
+      if (options.zone_extent_.length_) length_ = extent.length_;
+      if (options.zone_extent_.zone_id_) zone_start_ = extent.zone_->start_;
+    }
+  }
 
   uint64_t Start() const { return start_; }
   uint64_t Length() const { return length_; }
@@ -66,14 +127,27 @@ struct ZoneFileSnapshot {
   std::vector<ZoneExtentSnapshot> extent_;
 
  public:
-  ZoneFileSnapshot(ZoneFile& file)
-      : file_id_(file.GetID()), filename_(file.GetFilename()), extent_() {
-    for (ZoneExtent*& extent : file.GetExtents()) extent_.emplace_back(*extent);
+  ZoneFileSnapshot(ZoneFile& file, const ZenFSSnapshotOptions& options)
+      : file_id_(), filename_(), extent_() {
+    if (options.zone_file_.enabled_) {
+      if (options.zone_file_.id_) file_id_ = file.GetID();
+      if (options.zone_file_.filename_) filename_ = file.GetFilename();
+    }
+    if (options.zone_extent_.enabled_)
+      for (ZoneExtent* const& extent : file.GetExtents())
+        extent_.emplace_back(*extent, options);
   }
 
   uint64_t FileID() const { return file_id_; }
   const std::string& Filename() const { return filename_; }
   const std::vector<ZoneExtentSnapshot>& Extent() const { return extent_; }
+};
+
+struct ZenFSSnapshot {
+ public:
+  ZBDSnapshot zbd_;
+  std::vector<ZoneSnapshot> zones_;
+  std::vector<ZoneFileSnapshot> zone_files_;
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -468,9 +468,9 @@ unsigned int GetLifeTimeDiff(Env::WriteLifeTimeHint zone_lifetime,
 IOStatus ZonedBlockDevice::AllocateMetaZone(Zone **out_meta_zone) {
   assert(out_meta_zone);
   *out_meta_zone = nullptr;
-  ZenFSMetricsLatencyGuard guard(metrics_, ZENFS_META_ALLOC_LATENCY,
+  ZenFSMetricsLatencyGuard guard(metrics_, ZENFS_LABEL(META_ALLOC, LATENCY),
                                  Env::Default());
-  metrics_->ReportQPS(ZENFS_META_ALLOC_QPS, 1);
+  metrics_->ReportQPS(ZENFS_LABEL(META_ALLOC, QPS), 1);
 
   for (const auto z : meta_zones) {
     /* If the zone is not used, reset and use it */
@@ -516,9 +516,13 @@ IOStatus ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime,
   IOStatus s;
   bool ok = false;
   (void)ok;
-  ZenFSMetricsLatencyGuard guard(metrics_, ZENFS_IO_ALLOC_NON_WAL_LATENCY,
-                                 Env::Default());
-  metrics_->ReportQPS(ZENFS_IO_ALLOC_QPS, 1);
+  ZenFSMetricsLatencyGuard guard(
+      metrics_,
+      IOType::kUnknown == IOType::kWAL
+          ? ZENFS_LABEL_DETAILED(IO_ALLOC, WAL, LATENCY)
+          : ZENFS_LABEL_DETAILED(IO_ALLOC, NON_WAL, LATENCY),
+      Env::Default());
+  metrics_->ReportQPS(ZENFS_LABEL(IO_ALLOC, QPS), 1);
 
   *out_zone = nullptr;
 
@@ -677,8 +681,8 @@ IOStatus ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime,
 
   *out_zone = allocated_zone;
 
-  metrics_->ReportGeneral(ZENFS_OPEN_ZONES, open_io_zones_);
-  metrics_->ReportGeneral(ZENFS_ACTIVE_ZONES, active_io_zones_);
+  metrics_->ReportGeneral(ZENFS_LABEL(OPEN_ZONES, COUNT), open_io_zones_);
+  metrics_->ReportGeneral(ZENFS_LABEL(ACTIVE_ZONES, COUNT), active_io_zones_);
 
   return IOStatus::OK();
 }
@@ -724,8 +728,9 @@ void ZonedBlockDevice::SetZoneDeferredStatus(IOStatus status) {
   }
 }
 
-void ZonedBlockDevice::GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot) {
-  for (auto &zone : io_zones) snapshot.emplace_back(*zone);
+void ZonedBlockDevice::GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot,
+                                       const ZenFSSnapshotOptions &options) {
+  for (auto &zone : io_zones) snapshot.emplace_back(*zone, options);
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -31,6 +31,7 @@ namespace ROCKSDB_NAMESPACE {
 
 class ZonedBlockDevice;
 class ZoneSnapshot;
+class ZenFSSnapshotOptions;
 
 class Zone {
   ZonedBlockDevice *zbd_;
@@ -153,7 +154,8 @@ class ZonedBlockDevice {
 
   std::shared_ptr<ZenFSMetrics> GetMetrics() { return metrics_; }
 
-  void GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot);
+  void GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot,
+                       const ZenFSSnapshotOptions &options);
 
  private:
   std::string ErrorToString(int err);


### PR DESCRIPTION
Getting the state of the ZBD is different from others, for example the ZBD does not intentionally maintain a variable called free_space_, so we need to calculate the free space via a function GetFreeSpace().
    
Also, sometimes we would like to report these temporarily calculated values through metrics, and it is not a good idea to periodically calculate a variable in a specific function. So we added a ReportSnapshot interface to Metrics and left it up to the debugger to decide when to report them: the user can decide which variables to compute online via SnapshotOptions and then report them one by one via Metrics::ReportSnapshot().
    
We have added a sample related to this in metrics_example.h.
    
Signed-off-by: Liu Ruicheng <liuruicheng.222@bytedance.com>