### PR TITLE
log: enable logger by default and add garbage stats log

### DIFF
--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -134,6 +134,7 @@ class ZonedBlockDevice {
   Status ResetUnusedIOZones();
   void LogZoneStats();
   void LogZoneUsage();
+  void LogGarbageInfo();
 
   int GetReadFD() { return read_f_; }
   int GetReadDirectFD() { return read_direct_f_; }


### PR DESCRIPTION
We need to log important information in production mode, so for Release
or RelWithDebInfo build type, we could set log level to INFO_LEVEL.

The garbage stats log helps us understand the garbage distribution of
the disk and also let us know whether the collaborative GC works as
expected.

The log looks like this:

```
2021/12/14-22:43:21.776104 7f944bdfe700 Zone Garbage Stats: [545 10 2 8 6 15 16 12 9 24 9 0 ]
2021/12/14-22:43:22.777050 7f944bdfe700 Zone Garbage Stats: [544 11 2 8 6 15 16 12 9 24 9 0 ]
2021/12/14-22:43:23.777990 7f944bdfe700 Zone Garbage Stats: [544 11 2 8 6 15 16 12 9 24 9 0 ]
2021/12/14-22:43:24.778996 7f944bdfe700 Zone Garbage Stats: [545 10 1 8 7 15 16 12 9 24 9 0 ]
2021/12/14-22:43:25.779879 7f944bdfe700 Zone Garbage Stats: [545 10 1 8 7 15 16 12 9 24 9 0 ]
2021/12/14-22:43:26.780911 7f944bdfe700 Zone Garbage Stats: [545 10 1 8 7 15 16 12 9 24 9 0 ]
2021/12/14-22:43:27.782006 7f944bdfe700 Zone Garbage Stats: [545 10 1 8 6 15 16 13 9 24 9 0 ]
2021/12/14-22:43:28.783024 7f944bdfe700 Zone Garbage Stats: [545 10 1 8 6 15 16 13 9 24 9 0 ]
2021/12/14-22:43:29.783971 7f944bdfe700 Zone Garbage Stats: [545 10 1 8 6 15 16 12 9 25 9 0 ]
2021/12/14-22:43:30.784890 7f944bdfe700 Zone Garbage Stats: [545 10 1 8 6 15 16 12 9 25 9 0 ]
2021/12/14-22:43:31.785847 7f944bdfe700 Zone Garbage Stats: [545 9 2 8 6 15 16 12 9 25 9 0 ]
2021/12/14-22:43:32.786764 7f944bdfe700 Zone Garbage Stats: [544 10 2 8 6 15 16 12 9 24 10 0 ]
2021/12/14-22:43:33.787730 7f944bdfe700 Zone Garbage Stats: [544 10 2 8 6 15 16 12 9 24 10 0 ]
2021/12/14-22:43:34.788693 7f944bdfe700 Zone Garbage Stats: [545 9 1 8 7 15 16 12 9 24 10 0 ]
2021/12/14-22:43:35.789895 7f944bdfe700 Zone Garbage Stats: [545 9 1 8 7 15 16 12 9 24 10 0 ]
```

Signed-off-by: Kuankuan Guo <guokuankuan@bytedance.com>