### PR TITLE
Rework allocator to improve write QoS

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1024,7 +1024,7 @@ Status ZenFS::Mount(bool readonly) {
 
   if (!readonly) {
     Info(logger_, "Resetting unused IO Zones..");
-    Status status = zbd_->ResetUnusedIOZones();
+    IOStatus status = zbd_->ResetUnusedIOZones();
     if (!status.ok()) return status;
     Info(logger_, "  Done");
   }
@@ -1046,7 +1046,7 @@ Status ZenFS::MkFS(std::string aux_fs_path, uint32_t finish_threshold) {
   }
 
   ClearFiles();
-  Status status = zbd_->ResetUnusedIOZones();
+  IOStatus status = zbd_->ResetUnusedIOZones();
   if (!status.ok()) return status;
 
   for (const auto mz : metazones) {

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -238,12 +238,16 @@ IOStatus ZoneFile::CloseWR() {
 IOStatus ZoneFile::CloseActiveZone() {
   IOStatus s = IOStatus::OK();
   if (active_zone_) {
-    s = active_zone_->CloseWR();
+    bool full = active_zone_->IsFull();
+    s = active_zone_->Close();
     if (!s.ok()) {
       return s;
     }
     ReleaseActiveZone();
     zbd_->NotifyIOZoneClosed();
+    if (full) {
+      zbd_->NotifyIOZoneFull();
+    }
   }
   return s;
 }

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -198,6 +198,7 @@ ZoneFile::ZoneFile(ZonedBlockDevice* zbd, std::string filename,
       extent_start_(0),
       extent_filepos_(0),
       lifetime_(Env::WLTH_NOT_SET),
+      io_type_(IOType::kUnknown),
       fileSize(0),
       filename_(filename),
       file_id_(file_id),
@@ -211,6 +212,7 @@ time_t ZoneFile::GetFileModificationTime() { return m_time_; }
 uint64_t ZoneFile::GetFileSize() { return fileSize; }
 void ZoneFile::SetFileSize(uint64_t sz) { fileSize = sz; }
 void ZoneFile::SetFileModificationTime(time_t mt) { m_time_ = mt; }
+void ZoneFile::SetIOType(IOType io_type) { io_type_ = io_type; }
 
 ZoneFile::~ZoneFile() {
   for (auto e = std::begin(extents_); e != std::end(extents_); ++e) {
@@ -382,7 +384,7 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
 
   if (!active_zone_) {
     Zone* zone = nullptr;
-    s = zbd_->AllocateIOZone(lifetime_, &zone);
+    s = zbd_->AllocateIOZone(lifetime_, io_type_, &zone);
     if (!s.ok()) return s;
 
     if (!zone) {
@@ -405,7 +407,7 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
       }
 
       Zone* zone = nullptr;
-      s = zbd_->AllocateIOZone(lifetime_, &zone);
+      s = zbd_->AllocateIOZone(lifetime_, io_type_, &zone);
       if (!s.ok()) return s;
 
       if (!zone) {

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -244,9 +244,9 @@ IOStatus ZoneFile::CloseActiveZone() {
     if (!s.ok()) {
       return s;
     }
-    zbd_->NotifyIOZoneClosed();
+    zbd_->PutOpenIOZoneToken();
     if (full) {
-      zbd_->NotifyIOZoneFull();
+      zbd_->PutActiveIOZoneToken();
     }
   }
   return s;

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -382,7 +382,7 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
 
   if (!active_zone_) {
     Zone* zone = nullptr;
-    s = zbd_->AllocateZone(lifetime_, &zone);
+    s = zbd_->AllocateIOZone(lifetime_, &zone);
     if (!s.ok()) return s;
 
     if (!zone) {
@@ -405,7 +405,7 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
       }
 
       Zone* zone = nullptr;
-      s = zbd_->AllocateZone(lifetime_, &zone);
+      s = zbd_->AllocateIOZone(lifetime_, &zone);
       if (!s.ok()) return s;
 
       if (!zone) {

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -240,10 +240,10 @@ IOStatus ZoneFile::CloseActiveZone() {
   if (active_zone_) {
     bool full = active_zone_->IsFull();
     s = active_zone_->Close();
+    ReleaseActiveZone();
     if (!s.ok()) {
       return s;
     }
-    ReleaseActiveZone();
     zbd_->NotifyIOZoneClosed();
     if (full) {
       zbd_->NotifyIOZoneFull();

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -48,6 +48,7 @@ class ZoneFile {
   uint64_t extent_filepos_;
 
   Env::WriteLifeTimeHint lifetime_;
+  IOType io_type_; /* Only used when writing */
   uint64_t fileSize;
   std::string filename_;
   uint64_t file_id_;
@@ -68,6 +69,7 @@ class ZoneFile {
 
   IOStatus Append(void* data, int data_size, int valid_size);
   IOStatus SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime);
+  void SetIOType(IOType io_type);
   std::string GetFilename();
   void Rename(std::string name);
   time_t GetFileModificationTime();

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -722,12 +722,6 @@ IOStatus ZonedBlockDevice::AllocateIOZone(Env::WriteLifeTimeHint file_lifetime,
     return s;
   }
 
-  /* TODO: this should be done in context of deletes */
-  s = ResetUnusedIOZones();
-  if (!s.ok()) {
-    return s;
-  }
-
   WaitForOpenIOZoneToken();
 
   /* Try to fill an already open zone(with the best life time diff) */

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -710,8 +710,6 @@ IOStatus ZonedBlockDevice::AllocateIOZone(Env::WriteLifeTimeHint file_lifetime,
       Env::Default());
   metrics_->ReportQPS(ZENFS_LABEL(IO_ALLOC, QPS), 1);
 
-  *out_zone = nullptr;
-
   // Check if a deferred IO error was set
   s = GetZoneDeferredStatus();
   if (!s.ok()) {

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -65,16 +65,6 @@ bool Zone::IsFull() { return (capacity_ == 0); }
 bool Zone::IsEmpty() { return (wp_ == start_); }
 uint64_t Zone::GetZoneNr() { return start_ / zbd_->GetZoneSize(); }
 
-IOStatus Zone::CloseWR() {
-  assert(IsBusy());
-
-  IOStatus status = Close();
-
-  if (capacity_ == 0) zbd_->NotifyIOZoneFull();
-
-  return status;
-}
-
 void Zone::EncodeJson(std::ostream &json_stream) {
   json_stream << "{";
   json_stream << "\"start\":" << start_ << ",";

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -530,8 +530,8 @@ Status ZonedBlockDevice::ResetUnusedIOZones() {
   return Status::OK();
 }
 
-IOStatus ZonedBlockDevice::AllocateZone(Env::WriteLifeTimeHint file_lifetime,
-                                        Zone **out_zone) {
+IOStatus ZonedBlockDevice::AllocateIOZone(Env::WriteLifeTimeHint file_lifetime,
+                                          Zone **out_zone) {
   Zone *allocated_zone = nullptr;
   Zone *finish_victim = nullptr;
   unsigned int best_diff = LIFETIME_DIFF_NOT_GOOD;

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -81,7 +81,6 @@ class ZonedBlockDevice {
   uint64_t zone_sz_;
   uint32_t nr_zones_;
   std::vector<Zone *> io_zones;
-  std::mutex io_zones_mtx;
   std::vector<Zone *> meta_zones;
   int read_f_;
   int read_direct_f_;

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -119,7 +119,8 @@ class ZonedBlockDevice {
 
   Zone *GetIOZone(uint64_t offset);
 
-  IOStatus AllocateZone(Env::WriteLifeTimeHint file_lifetime, Zone **out_zone);
+  IOStatus AllocateIOZone(Env::WriteLifeTimeHint file_lifetime,
+                          Zone **out_zone);
   IOStatus AllocateMetaZone(Zone **out_meta_zone);
 
   uint64_t GetFreeSpace();

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -161,6 +161,7 @@ class ZonedBlockDevice {
   std::string ErrorToString(int err);
   IOStatus GetZoneDeferredStatus();
   IOStatus ApplyFinishThreshold();
+  IOStatus FinishCheapestIOZone();
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -160,6 +160,7 @@ class ZonedBlockDevice {
  private:
   std::string ErrorToString(int err);
   IOStatus GetZoneDeferredStatus();
+  IOStatus ApplyFinishThreshold();
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -71,8 +71,6 @@ class Zone {
 
   void EncodeJson(std::ostream &json_stream);
 
-  IOStatus CloseWR(); /* Done writing */
-
   inline IOStatus CheckRelease();
 };
 

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -145,8 +145,8 @@ class ZonedBlockDevice {
 
   void SetFinishTreshold(uint32_t threshold) { finish_threshold_ = threshold; }
 
-  void NotifyIOZoneFull();
-  void NotifyIOZoneClosed();
+  void PutOpenIOZoneToken();
+  void PutActiveIOZoneToken();
 
   void EncodeJson(std::ostream &json_stream);
 
@@ -160,6 +160,8 @@ class ZonedBlockDevice {
  private:
   std::string ErrorToString(int err);
   IOStatus GetZoneDeferredStatus();
+  bool GetActiveIOZoneTokenIfAvailable();
+  void WaitForOpenIOZoneToken();
   IOStatus ApplyFinishThreshold();
   IOStatus FinishCheapestIOZone();
   IOStatus GetBestOpenZoneMatch(Env::WriteLifeTimeHint file_lifetime,

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -161,7 +161,7 @@ class ZonedBlockDevice {
   std::string ErrorToString(int err);
   IOStatus GetZoneDeferredStatus();
   bool GetActiveIOZoneTokenIfAvailable();
-  void WaitForOpenIOZoneToken();
+  void WaitForOpenIOZoneToken(bool prioritized);
   IOStatus ApplyFinishThreshold();
   IOStatus FinishCheapestIOZone();
   IOStatus GetBestOpenZoneMatch(Env::WriteLifeTimeHint file_lifetime,

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -164,6 +164,7 @@ class ZonedBlockDevice {
   IOStatus FinishCheapestIOZone();
   IOStatus GetBestOpenZoneMatch(Env::WriteLifeTimeHint file_lifetime,
                                 unsigned int *best_diff_out, Zone **zone_out);
+  IOStatus AllocateEmptyZone(Zone **zone_out);
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -162,6 +162,8 @@ class ZonedBlockDevice {
   IOStatus GetZoneDeferredStatus();
   IOStatus ApplyFinishThreshold();
   IOStatus FinishCheapestIOZone();
+  IOStatus GetBestOpenZoneMatch(Env::WriteLifeTimeHint file_lifetime,
+                                unsigned int *best_diff_out, Zone **zone_out);
 };
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -25,6 +25,7 @@
 
 #include "metrics.h"
 #include "rocksdb/env.h"
+#include "rocksdb/file_system.h"
 #include "rocksdb/io_status.h"
 
 namespace ROCKSDB_NAMESPACE {
@@ -118,7 +119,7 @@ class ZonedBlockDevice {
 
   Zone *GetIOZone(uint64_t offset);
 
-  IOStatus AllocateIOZone(Env::WriteLifeTimeHint file_lifetime,
+  IOStatus AllocateIOZone(Env::WriteLifeTimeHint file_lifetime, IOType io_type,
                           Zone **out_zone);
   IOStatus AllocateMetaZone(Zone **out_meta_zone);
 

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -130,7 +130,7 @@ class ZonedBlockDevice {
   std::string GetFilename();
   uint32_t GetBlockSize();
 
-  Status ResetUnusedIOZones();
+  IOStatus ResetUnusedIOZones();
   void LogZoneStats();
   void LogZoneUsage();
   void LogGarbageInfo();


### PR DESCRIPTION
This pull request reworks the IO Zone allocator to reduce write latencies
Summary of commit messages below:

  fs: priortize open resources for WAL to avoid starvation

    Reserve one open topen for write ahead log allocation
    to avoid WAL writes being stalled due to the compaction
    eating up all open resources.

    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

  fs: avoid finishes in allocator by relaxing the life time diff requirement

    If the write buffer is not big enough to fill a zone, the first-level ssts
    will end up as many small files and cause the allocator to finish a lot of zones as the
    write life time diff requirement cannot be met.

    Avoid the finishes by allowing same-level-ssts to co-locate the same zones
    when we're at the max active limit.

    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

  fs: avoid zone threshold finishes when doing WAL allocations

    Treshold finishes adds allocation (and thereby write) latency,
    so avoid threshold finishes when allocating for the write-ahead
    log.

    Also skip doing zone stat logging during WAL allocation
    as this might impact latencies as well.

    The WAL-identification (setting IO type) is based on a
    patch by Kuankuan Guo. RocksDB does not set IO Type
    at the moment, so we have to rely on file extension
    identification.

    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

  fs: reset unused io zones on file deletes

    Move io zone resets to the context of deletes, this
    removes the need on zone resets on the allocation path.

    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

  fs: refactor and make the IO Zone allocator re-entrant

    Make the IO Zone re-entrant in order parallelize zone allocation,
    allowing the WAL files to get a zone immediately even though
    an SST file might be waiting for a finish to be able to allocate
    a new zone.

    In order to do this in a safe way, introduce a token-api for
    active and open zones. Also give the allocator code a well-deserved
    refactor makeover.

    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>
