### PR TITLE
Implement inline extents

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -393,7 +393,7 @@ IOStatus ZenFS::PersistRecord(std::string record) {
   return s;
 }
 
-IOStatus ZenFS::SyncFileMetadata(std::shared_ptr<ZoneFile> zoneFile) {
+IOStatus ZenFS::SyncFileMetadata(ZoneFile* zoneFile) {
   std::string fileRecord;
   std::string output;
   IOStatus s;

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -263,8 +263,9 @@ void ZenFS::LogFiles() {
     std::shared_ptr<ZoneFile> zFile = it->second;
     std::vector<ZoneExtent*> extents = zFile->GetExtents();
 
-    Info(logger_, "    %-45s sz: %lu lh: %d", it->first.c_str(),
-         zFile->GetFileSize(), zFile->GetWriteLifeTimeHint());
+    Info(logger_, "    %-45s sz: %lu lh: %d sparse: %u", it->first.c_str(),
+         zFile->GetFileSize(), zFile->GetWriteLifeTimeHint(),
+         zFile->IsSparse());
     for (unsigned int i = 0; i < extents.size(); i++) {
       ZoneExtent* extent = extents[i];
       Info(logger_, "          Extent %u {start=0x%lx, zone=%u, len=%u} ", i,
@@ -523,6 +524,8 @@ IOStatus ZenFS::NewWritableFile(const std::string& fname,
   } else {
     zoneFile->SetIOType(IOType::kUnknown);
   }
+
+  zoneFile->SetSparse(!file_opts.use_direct_writes);
 
   /* Persist the creation of the file */
   s = SyncFileMetadata(zoneFile);

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -185,6 +185,7 @@ class ZenFS : public FileSystemWrapper {
   std::shared_ptr<ZoneFile> GetFileInternal(std::string fname);
   std::shared_ptr<ZoneFile> GetFile(std::string fname);
   IOStatus DeleteFile(std::string fname);
+  IOStatus Repair();
 
  public:
   explicit ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -132,16 +132,16 @@ class ZenFS : public FileSystemWrapper {
 
   std::shared_ptr<Logger> GetLogger() { return logger_; }
 
-  struct MetadataWriter : public ZonedWritableFile::MetadataWriter {
+  struct ZenFSMetadataWriter : public MetadataWriter {
     ZenFS* zenFS;
-    IOStatus Persist(std::shared_ptr<ZoneFile> zoneFile) {
+    IOStatus Persist(ZoneFile* zoneFile) {
       Debug(zenFS->GetLogger(), "Syncing metadata for: %s",
             zoneFile->GetFilename().c_str());
       return zenFS->SyncFileMetadata(zoneFile);
     }
   };
 
-  MetadataWriter metadata_writer_;
+  ZenFSMetadataWriter metadata_writer_;
 
   enum ZenFSTag : uint32_t {
     kCompleteFilesSnapshot = 1,
@@ -157,7 +157,10 @@ class ZenFS : public FileSystemWrapper {
   IOStatus RollMetaZoneLocked();
   IOStatus PersistSnapshot(ZenMetaLog* meta_writer);
   IOStatus PersistRecord(std::string record);
-  IOStatus SyncFileMetadata(std::shared_ptr<ZoneFile> zoneFile);
+  IOStatus SyncFileMetadata(ZoneFile* zoneFile);
+  IOStatus SyncFileMetadata(std::shared_ptr<ZoneFile> zoneFile) {
+    return SyncFileMetadata(zoneFile.get());
+  }
 
   void EncodeSnapshotTo(std::string* output);
   void EncodeFileDeletionTo(std::shared_ptr<ZoneFile> zoneFile,

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -60,6 +60,7 @@ enum ZoneFileTag : uint32_t {
   kExtent = 5,
   kModificationTime = 6,
   kActiveExtentStart = 7,
+  kIsSparse = 8,
 };
 
 void ZoneFile::EncodeTo(std::string* output, uint32_t extent_start) {
@@ -93,6 +94,10 @@ void ZoneFile::EncodeTo(std::string* output, uint32_t extent_start) {
    * from extent_start_ */
   PutFixed32(output, kActiveExtentStart);
   PutFixed64(output, extent_start_);
+
+  if (is_sparse_) {
+    PutFixed32(output, kIsSparse);
+  }
 }
 
 void ZoneFile::EncodeJson(std::ostream& json_stream) {
@@ -173,6 +178,9 @@ Status ZoneFile::DecodeFrom(Slice* input) {
           return Status::Corruption("ZoneFile", "Active extent start");
         extent_start_ = es;
         break;
+      case kIsSparse:
+        is_sparse_ = true;
+        break;
       default:
         return Status::Corruption("ZoneFile", "Unexpected tag");
     }
@@ -198,7 +206,8 @@ Status ZoneFile::MergeUpdate(std::shared_ptr<ZoneFile> update) {
     zone->used_capacity_ += extent->length_;
     extents_.push_back(new ZoneExtent(extent->start_, extent->length_, zone));
   }
-
+  extent_start_ = update->GetExtentStart();
+  is_sparse_ = update->IsSparse();
   MetadataSynced();
 
   return Status::OK();
@@ -243,8 +252,8 @@ ZoneFile::~ZoneFile() {
 
 IOStatus ZoneFile::CloseWR() {
   IOStatus s = CloseActiveZone();
+  extent_start_ = NO_EXTENT;
   open_for_wr_ = false;
-  metadata_writer_ = NULL;
   return s;
 }
 
@@ -273,9 +282,6 @@ void ZoneFile::OpenWR(MetadataWriter* metadata_writer) {
 bool ZoneFile::IsOpenForWR() { return open_for_wr_; }
 
 IOStatus ZoneFile::PersistMetadata() {
-  /* If the file is open read-only, all metadata is up to date on disk */
-  if (!open_for_wr_) return IOStatus::OK();
-
   assert(metadata_writer_ != NULL);
   return metadata_writer_->Persist(this);
 }
@@ -367,7 +373,6 @@ IOStatus ZoneFile::PositionedRead(uint64_t offset, size_t n, Slice* result,
       }
       r_off = extent->start_;
       extent_end = extent->start_ + extent->length_;
-      assert(((size_t)r_off % zbd_->GetBlockSize()) == 0);
     }
   }
 
@@ -415,8 +420,67 @@ IOStatus ZoneFile::AllocateNewZone() {
   return PersistMetadata();
 }
 
+/* Byte-aligned, sparse writes with inline metadata
+   the caller reserves 8 bytes of data for a size header */
+IOStatus ZoneFile::SparseAppend(char* sparse_buffer, uint32_t data_size) {
+  uint32_t left = data_size;
+  uint32_t wr_size;
+  uint32_t block_sz = GetBlockSize();
+  IOStatus s;
+
+  if (active_zone_ == NULL) {
+    s = AllocateNewZone();
+    if (!s.ok()) return s;
+  }
+
+  while (left) {
+    wr_size = left + ZoneFile::SPARSE_HEADER_SIZE;
+    if (wr_size > active_zone_->capacity_) wr_size = active_zone_->capacity_;
+
+    /* Pad to the next block boundary if needed */
+    uint32_t align = wr_size % block_sz;
+    uint32_t pad_sz = 0;
+
+    if (align) pad_sz = block_sz - align;
+
+    /* the sparse buffer has block_sz extra bytes tail allocated for padding, so
+     * this is safe */
+    if (pad_sz) memset(sparse_buffer + wr_size, 0x0, pad_sz);
+
+    uint64_t extent_length = wr_size - ZoneFile::SPARSE_HEADER_SIZE;
+    EncodeFixed64(sparse_buffer, extent_length);
+
+    s = active_zone_->Append(sparse_buffer, wr_size + pad_sz);
+    if (!s.ok()) return s;
+
+    extents_.push_back(
+        new ZoneExtent(extent_start_ + ZoneFile::SPARSE_HEADER_SIZE,
+                       extent_length, active_zone_));
+
+    extent_start_ = active_zone_->wp_;
+    active_zone_->used_capacity_ += extent_length;
+    fileSize += extent_length;
+    left -= extent_length;
+
+    if (active_zone_->capacity_ == 0) {
+      s = CloseActiveZone();
+      if (!s.ok()) {
+        return s;
+      }
+      if (left) {
+        memcpy((void*)(sparse_buffer + ZoneFile::SPARSE_HEADER_SIZE),
+               (void*)(sparse_buffer + wr_size), left);
+      }
+      s = AllocateNewZone();
+      if (!s.ok()) return s;
+    }
+  }
+
+  return IOStatus::OK();
+}
+
 /* Assumes that data and size are block aligned */
-IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
+IOStatus ZoneFile::Append(void* data, int data_size) {
   uint32_t left = data_size;
   uint32_t wr_size, offset = 0;
   IOStatus s = IOStatus::OK();
@@ -450,8 +514,7 @@ IOStatus ZoneFile::Append(void* data, int data_size, int valid_size) {
     offset += wr_size;
   }
 
-  fileSize -= (data_size - valid_size);
-  return s;
+  return IOStatus::OK();
 }
 
 IOStatus ZoneFile::SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime) {
@@ -481,17 +544,27 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
 
   buffered = _buffered;
   block_sz = zbd->GetBlockSize();
-  buffer_sz = block_sz * 256;
-  buffer_pos = 0;
-
   zoneFile_ = zoneFile;
+  buffer_pos = 0;
+  sparse_buffer = nullptr;
+  buffer = nullptr;
 
   if (buffered) {
-    int ret = posix_memalign((void**)&buffer, sysconf(_SC_PAGESIZE), buffer_sz);
+    size_t sparse_buffer_sz;
 
-    if (ret) buffer = nullptr;
+    sparse_buffer_sz =
+        1024 * 1024 + block_sz; /* one extra block size for padding */
+    int ret = posix_memalign((void**)&sparse_buffer, sysconf(_SC_PAGESIZE),
+                             sparse_buffer_sz);
 
-    assert(buffer != nullptr);
+    if (ret) sparse_buffer = nullptr;
+
+    assert(sparse_buffer != nullptr);
+
+    buffer_sz = sparse_buffer_sz - ZoneFile::SPARSE_HEADER_SIZE - block_sz;
+    buffer = sparse_buffer + ZoneFile::SPARSE_HEADER_SIZE;
+
+    zoneFile_->SetSparse(true);
   }
 
   zoneFile_->OpenWR(metadata_writer);
@@ -499,7 +572,7 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
 
 ZonedWritableFile::~ZonedWritableFile() {
   IOStatus s = zoneFile_->CloseWR();
-  if (buffered) free(buffer);
+  if (buffered) free(sparse_buffer);
 
   if (!s.ok()) {
     zoneFile_->GetZbd()->SetZoneDeferredStatus(s);
@@ -515,6 +588,25 @@ IOStatus ZonedWritableFile::Truncate(uint64_t size,
   return IOStatus::OK();
 }
 
+IOStatus ZonedWritableFile::DataSync() {
+  if (buffered) {
+    IOStatus s;
+    buffer_mtx_.lock();
+    /* Flushing the buffer will result in a new extent added to the list*/
+    s = FlushBuffer();
+    buffer_mtx_.unlock();
+    if (!s.ok()) {
+      return s;
+    }
+  } else {
+    /* For direct writes, there is no buffer to flush, we just need to push
+       an extent for the latest written data */
+    zoneFile_->PushExtent();
+  }
+
+  return IOStatus::OK();
+}
+
 IOStatus ZonedWritableFile::Fsync(const IOOptions& /*options*/,
                                   IODebugContext* /*dbg*/) {
   IOStatus s;
@@ -526,19 +618,15 @@ IOStatus ZonedWritableFile::Fsync(const IOOptions& /*options*/,
       Env::Default());
   zoneFile_->GetZBDMetrics()->ReportQPS(ZENFS_LABEL(SYNC, QPS), 1);
 
-  buffer_mtx_.lock();
-  s = FlushBuffer();
-  buffer_mtx_.unlock();
-  if (!s.ok()) {
-    return s;
-  }
-  zoneFile_->PushExtent();
+  s = DataSync();
+  if (!s.ok()) return s;
+
   return zoneFile_->PersistMetadata();
 }
 
-IOStatus ZonedWritableFile::Sync(const IOOptions& options,
-                                 IODebugContext* dbg) {
-  return Fsync(options, dbg);
+IOStatus ZonedWritableFile::Sync(const IOOptions& /*options*/,
+                                 IODebugContext* /*dbg*/) {
+  return DataSync();
 }
 
 IOStatus ZonedWritableFile::Flush(const IOOptions& /*options*/,
@@ -547,32 +635,30 @@ IOStatus ZonedWritableFile::Flush(const IOOptions& /*options*/,
 }
 
 IOStatus ZonedWritableFile::RangeSync(uint64_t offset, uint64_t nbytes,
-                                      const IOOptions& options,
-                                      IODebugContext* dbg) {
-  if (wp < offset + nbytes) return Fsync(options, dbg);
+                                      const IOOptions& /*options*/,
+                                      IODebugContext* /*dbg*/) {
+  if (wp < offset + nbytes) return DataSync();
 
   return IOStatus::OK();
 }
 
-IOStatus ZonedWritableFile::Close(const IOOptions& options,
-                                  IODebugContext* dbg) {
-  Fsync(options, dbg);
-  return zoneFile_->CloseWR();
+IOStatus ZonedWritableFile::Close(const IOOptions& /*options*/,
+                                  IODebugContext* /*dbg*/) {
+  IOStatus s = DataSync();
+  if (!s.ok()) return s;
+
+  s = zoneFile_->CloseWR();
+  if (!s.ok()) return s;
+
+  return zoneFile_->PersistMetadata();
 }
 
 IOStatus ZonedWritableFile::FlushBuffer() {
-  uint32_t align, pad_sz = 0, wr_sz;
   IOStatus s;
 
-  if (!buffer_pos) return IOStatus::OK();
+  if (buffer_pos == 0) return IOStatus::OK();
 
-  align = buffer_pos % block_sz;
-  if (align) pad_sz = block_sz - align;
-
-  if (pad_sz) memset((char*)buffer + buffer_pos, 0x0, pad_sz);
-
-  wr_sz = buffer_pos + pad_sz;
-  s = zoneFile_->Append((char*)buffer, wr_sz, buffer_pos);
+  s = zoneFile_->SparseAppend(sparse_buffer, buffer_pos);
   if (!s.ok()) {
     return s;
   }
@@ -584,59 +670,29 @@ IOStatus ZonedWritableFile::FlushBuffer() {
 }
 
 IOStatus ZonedWritableFile::BufferedWrite(const Slice& slice) {
-  uint32_t buffer_left = buffer_sz - buffer_pos;
   uint32_t data_left = slice.size();
   char* data = (char*)slice.data();
-  uint32_t tobuffer;
-  int blocks, aligned_sz;
-  int ret;
-  void* alignbuf;
   IOStatus s;
 
-  if (buffer_pos || data_left <= buffer_left) {
-    if (data_left < buffer_left) {
-      tobuffer = data_left;
-    } else {
-      tobuffer = buffer_left;
+  while (data_left) {
+    uint32_t buffer_left = buffer_sz - buffer_pos;
+    uint32_t to_buffer;
+
+    if (!buffer_left) {
+      s = FlushBuffer();
+      if (!s.ok()) return s;
+      buffer_left = buffer_sz;
     }
 
-    memcpy(buffer + buffer_pos, data, tobuffer);
-    buffer_pos += tobuffer;
-    data_left -= tobuffer;
-
-    if (!data_left) return IOStatus::OK();
-
-    data += tobuffer;
-  }
-
-  if (buffer_pos == buffer_sz) {
-    s = FlushBuffer();
-    if (!s.ok()) return s;
-  }
-
-  if (data_left >= buffer_sz) {
-    blocks = data_left / block_sz;
-    aligned_sz = block_sz * blocks;
-
-    ret = posix_memalign(&alignbuf, sysconf(_SC_PAGESIZE), aligned_sz);
-    if (ret) {
-      return IOStatus::IOError("failed allocating alignment write buffer\n");
+    to_buffer = data_left;
+    if (to_buffer > buffer_left) {
+      to_buffer = buffer_left;
     }
 
-    memcpy(alignbuf, data, aligned_sz);
-    s = zoneFile_->Append(alignbuf, aligned_sz, aligned_sz);
-    free(alignbuf);
-
-    if (!s.ok()) return s;
-
-    wp += aligned_sz;
-    data_left -= aligned_sz;
-    data += aligned_sz;
-  }
-
-  if (data_left) {
-    memcpy(buffer, data, data_left);
-    buffer_pos = data_left;
+    memcpy(buffer + buffer_pos, data, to_buffer);
+    buffer_pos += to_buffer;
+    data_left -= to_buffer;
+    data += to_buffer;
   }
 
   return IOStatus::OK();
@@ -661,7 +717,7 @@ IOStatus ZonedWritableFile::Append(const Slice& data,
     s = BufferedWrite(data);
     buffer_mtx_.unlock();
   } else {
-    s = zoneFile_->Append((void*)data.data(), data.size(), data.size());
+    s = zoneFile_->Append((void*)data.data(), data.size());
     if (s.ok()) wp += data.size();
   }
 
@@ -683,7 +739,7 @@ IOStatus ZonedWritableFile::PositionedAppend(const Slice& data, uint64_t offset,
     s = BufferedWrite(data);
     buffer_mtx_.unlock();
   } else {
-    s = zoneFile_->Append((void*)data.data(), data.size(), data.size());
+    s = zoneFile_->Append((void*)data.data(), data.size());
     if (s.ok()) wp += data.size();
   }
 

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -59,6 +59,7 @@ enum ZoneFileTag : uint32_t {
   kWriteLifeTimeHint = 4,
   kExtent = 5,
   kModificationTime = 6,
+  kActiveExtentStart = 7,
 };
 
 void ZoneFile::EncodeTo(std::string* output, uint32_t extent_start) {
@@ -84,8 +85,14 @@ void ZoneFile::EncodeTo(std::string* output, uint32_t extent_start) {
 
   PutFixed32(output, kModificationTime);
   PutFixed64(output, (uint64_t)m_time_);
-  /* We're not encoding active zone and extent start
-   * as files will always be read-only after mount */
+
+  /* We store the current extent start - if there is a crash
+   * we know that this file wrote the data starting from
+   * active extent start up to the zone write pointer.
+   * We don't need to store the active zone as we can look it up
+   * from extent_start_ */
+  PutFixed32(output, kActiveExtentStart);
+  PutFixed64(output, extent_start_);
 }
 
 void ZoneFile::EncodeJson(std::ostream& json_stream) {
@@ -159,6 +166,12 @@ Status ZoneFile::DecodeFrom(Slice* input) {
         if (!GetFixed64(input, &ct))
           return Status::Corruption("ZoneFile", "Missing creation time");
         m_time_ = (time_t)ct;
+        break;
+      case kActiveExtentStart:
+        uint64_t es;
+        if (!GetFixed64(input, &es))
+          return Status::Corruption("ZoneFile", "Active extent start");
+        extent_start_ = es;
         break;
       default:
         return Status::Corruption("ZoneFile", "Unexpected tag");

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -217,7 +217,7 @@ ZoneFile::ZoneFile(ZonedBlockDevice* zbd, std::string filename,
                    uint64_t file_id)
     : zbd_(zbd),
       active_zone_(NULL),
-      extent_start_(0),
+      extent_start_(NO_EXTENT),
       extent_filepos_(0),
       lifetime_(Env::WLTH_NOT_SET),
       io_type_(IOType::kUnknown),
@@ -512,6 +512,100 @@ IOStatus ZoneFile::Append(void* data, int data_size) {
     fileSize += wr_size;
     left -= wr_size;
     offset += wr_size;
+  }
+
+  return IOStatus::OK();
+}
+
+IOStatus ZoneFile::RecoverSparseExtents(uint64_t start, uint64_t end,
+                                        Zone* zone) {
+  /* Sparse writes, we need to recover each individual segment */
+  IOStatus s;
+  uint32_t block_sz = GetBlockSize();
+  int f = zbd_->GetReadFD();
+  uint64_t next_extent_start = start;
+  char* buffer;
+  int recovered_segments = 0;
+  int ret;
+
+  ret = posix_memalign((void**)&buffer, sysconf(_SC_PAGESIZE), block_sz);
+  if (ret) {
+    return IOStatus::IOError("Out of memory while recovering");
+  }
+
+  while (next_extent_start < end) {
+    uint64_t extent_length;
+
+    ret = pread(f, (void*)buffer, block_sz, next_extent_start);
+    if (ret != (int)block_sz) {
+      s = IOStatus::IOError("Unexpected read error while recovering");
+      break;
+    }
+
+    extent_length = DecodeFixed64(buffer);
+    if (extent_length == 0) {
+      s = IOStatus::IOError("Unexexpeted extent length while recovering");
+      break;
+    }
+    recovered_segments++;
+
+    zone->used_capacity_ += extent_length;
+    extents_.push_back(new ZoneExtent(next_extent_start + SPARSE_HEADER_SIZE,
+                                      extent_length, zone));
+
+    uint64_t extent_blocks = 1 + extent_length / block_sz;
+    next_extent_start += extent_blocks * block_sz;
+  }
+
+  free(buffer);
+  return s;
+}
+
+IOStatus ZoneFile::Recover() {
+  /* If there is no active extent, the file was either closed gracefully
+     or there were no writes prior to a crash. All good.*/
+  if (!HasActiveExtent()) return IOStatus::OK();
+
+  /* Figure out which zone we were writing to */
+  Zone* zone = zbd_->GetIOZone(extent_start_);
+
+  if (zone == nullptr) {
+    return IOStatus::IOError(
+        "Could not find zone for extent start while recovering");
+  }
+
+  if (zone->wp_ < extent_start_) {
+    return IOStatus::IOError("Zone wp is smaller than active extent start");
+  }
+
+  /* How much data do we need to recover? */
+  uint64_t to_recover = zone->wp_ - extent_start_;
+
+  /* Do we actually have any data to recover? */
+  if (to_recover == 0) {
+    /* Mark up the file as having no missing extents */
+    extent_start_ = NO_EXTENT;
+    return IOStatus::OK();
+  }
+
+  /* Is the data sparse or was it writted direct? */
+  if (is_sparse_) {
+    IOStatus s = RecoverSparseExtents(extent_start_, zone->wp_, zone);
+    if (!s.ok()) return s;
+  } else {
+    /* For non-sparse files, the data is contigous and we can recover directly
+       any missing data using the WP */
+    zone->used_capacity_ += to_recover;
+    extents_.push_back(new ZoneExtent(extent_start_, to_recover, zone));
+  }
+
+  /* Mark up the file as having no missing extents */
+  extent_start_ = NO_EXTENT;
+
+  /* Recalculate file size */
+  fileSize = 0;
+  for (uint32_t i = 0; i < extents_.size(); i++) {
+    fileSize += extents_[i]->length_;
   }
 
   return IOStatus::OK();

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -40,12 +40,16 @@ class ZoneExtent {
 };
 
 class ZoneFile {
- protected:
+ private:
+  const uint64_t NO_EXTENT = 0xffffffffffffffff;
+
   ZonedBlockDevice* zbd_;
+
   std::vector<ZoneExtent*> extents_;
+
   Zone* active_zone_;
-  uint64_t extent_start_;
-  uint64_t extent_filepos_;
+  uint64_t extent_start_ = NO_EXTENT;
+  uint64_t extent_filepos_ = 0;
 
   Env::WriteLifeTimeHint lifetime_;
   IOType io_type_; /* Only used when writing */
@@ -53,7 +57,7 @@ class ZoneFile {
   std::string filename_;
   uint64_t file_id_;
 
-  uint32_t nr_synced_extents_;
+  uint32_t nr_synced_extents_ = 0;
   bool open_for_wr_ = false;
   time_t m_time_;
 

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -69,10 +69,13 @@ class ZoneFile {
   uint32_t nr_synced_extents_ = 0;
   bool open_for_wr_ = false;
   time_t m_time_;
+  bool is_sparse_ = false;
 
   MetadataWriter* metadata_writer_ = NULL;
 
  public:
+  static const int SPARSE_HEADER_SIZE = 8;
+
   explicit ZoneFile(ZonedBlockDevice* zbd, std::string filename,
                     uint64_t file_id_);
 
@@ -83,7 +86,8 @@ class ZoneFile {
   bool IsOpenForWR();
   IOStatus PersistMetadata();
 
-  IOStatus Append(void* data, int data_size, int valid_size);
+  IOStatus Append(void* buffer, int data_size);
+  IOStatus SparseAppend(char* data, uint32_t size);
   IOStatus SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime);
   void SetIOType(IOType io_type);
   std::string GetFilename();
@@ -117,6 +121,12 @@ class ZoneFile {
 
   uint64_t GetID() { return file_id_; }
   size_t GetUniqueId(char* id, size_t max_size);
+
+  bool IsSparse() { return is_sparse_; };
+
+  void SetSparse(bool is_sparse) { is_sparse_ = is_sparse; };
+  uint64_t HasActiveExtent() { return extent_start_ != NO_EXTENT; };
+  uint64_t GetExtentStart() { return extent_start_; };
 
  private:
   void ReleaseActiveZone();
@@ -176,8 +186,10 @@ class ZonedWritableFile : public FSWritableFile {
  private:
   IOStatus BufferedWrite(const Slice& data);
   IOStatus FlushBuffer();
+  IOStatus DataSync();
 
   bool buffered;
+  char* sparse_buffer;
   char* buffer;
   size_t buffer_sz;
   uint32_t block_sz;

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -128,6 +128,8 @@ class ZoneFile {
   uint64_t HasActiveExtent() { return extent_start_ != NO_EXTENT; };
   uint64_t GetExtentStart() { return extent_start_; };
 
+  IOStatus Recover();
+
  private:
   void ReleaseActiveZone();
   void SetActiveZone(Zone* zone);
@@ -136,6 +138,7 @@ class ZoneFile {
  public:
   std::shared_ptr<ZenFSMetrics> GetZBDMetrics() { return zbd_->GetMetrics(); }
   IOType GetIOType() const { return IOType::kUnknown; }
+  IOStatus RecoverSparseExtents(uint64_t start, uint64_t end, Zone* zone);
 };
 
 class ZonedWritableFile : public FSWritableFile {


### PR DESCRIPTION
This PR reduces write tail latency and increases throughput for use cases that require synced writes (db_bench --sync=1 ..)  when all written key/values must be persisted directly and readable after a potenial crash.

The trick is to store the active extent start that we are writing to for each file and use the write pointer to recover the data in case of a crash. For non-block-size aligned writes, like the WAL, a sparse format is introduced where the length of each non-aligned segment is prefixed to the data, so each write contains the valid data length.

With these changes, we only need to write to the metadata zone when we a) allocate a new extent b) close the file.


```
 fs: implement file recovery based on active extent information
    
    We can now recover data from files that has not been fsynced
    by busing active extent start and the wp in the active extent
    zone's wp.
    
    For sparse files(that has segment lenght in line
    with the data stored) we need to go through each individual
    segment and re-create all non-synced extents.
    
    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

 fs: Split buffered and non-buffered appends
    
    Make buffered writes sparse.
    
    Now that we store the extent lengths in line with data
    for every buffer flush, we don't have to write metadata records
    when asked to do a data sync.
    
    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

 fs: refactor ZoneFile::Append
    
    Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>

 fs: store active extent start
    
    If we store the current extent start and there is a crash
    we know that this file wrote the data starting from
    active extent start up to the zone write pointer.
    
    We don't need to store the active zone as we can look it up
    from extent_start_
    
```

This PR requires a bit of extra work before we can release it. The following issue has been created to cover that:

https://github.com/westerndigitalcorporation/zenfs/issues/118