### PR TITLE
metrics: refactor metrics, reduce code complexity

### DIFF
--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -372,8 +372,6 @@ class ZenFS : public FileSystemWrapper {
     return IOStatus::NotSupported("AreFilesSame is not supported in ZenFS");
   }
 
-  void GetZoneSnapshot(std::vector<ZoneSnapshot>& zones);
-  void GetZoneFileSnapshot(std::vector<ZoneFileSnapshot>& zone_files);
   void GetZenFSSnapshot(ZenFSSnapshot& snapshot,
                         const ZenFSSnapshotOptions& options);
 };

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -176,6 +176,7 @@ class ZonedWritableFile : public FSWritableFile {
                              IODebugContext* dbg) override;
   virtual IOStatus Fsync(const IOOptions& options,
                          IODebugContext* dbg) override;
+
   bool use_direct_io() const override { return !buffered; }
   bool IsSyncThreadSafe() const override { return true; };
   size_t GetRequiredBufferAlignment() const override {

--- a/fs/metrics.h
+++ b/fs/metrics.h
@@ -31,8 +31,7 @@ struct ZenFSMetrics {
   // You can give a type for type-checking.
   virtual void Report(Label label, size_t value,
                       ReporterType type_check = 0) = 0;
-  virtual void ReportSnapshot(const ZenFSSnapshot& snapshot,
-                              const ZenFSSnapshotOptions& options) = 0;
+  virtual void ReportSnapshot(const ZenFSSnapshot& snapshot) = 0;
 
  public:
   // Syntactic sugars for type-checking.
@@ -59,9 +58,7 @@ struct NoZenFSMetrics : public ZenFSMetrics {
   virtual void AddReporter(uint32_t /*label*/, uint32_t /*type*/) override {}
   virtual void Report(uint32_t /*label*/, size_t /*value*/,
                       uint32_t /*type_check*/) override {}
-  virtual void ReportSnapshot(
-      const ZenFSSnapshot& /*snapshot*/,
-      const ZenFSSnapshotOptions& /*options*/) override {}
+  virtual void ReportSnapshot(const ZenFSSnapshot& /*snapshot*/) override {}
 };
 
 // The implementation of this class will start timing when initialized,

--- a/fs/metrics_sample.h
+++ b/fs/metrics_sample.h
@@ -161,12 +161,10 @@ struct ZenFSMetricsSample : public ZenFSMetrics {
       } break;
     }
   }
-  virtual void ReportSnapshot(const ZenFSSnapshot& snapshot,
-                              const ZenFSSnapshotOptions& options) {
-    if (options.zbd_.get_free_space_) {
-      uint64_t free_space_gb = snapshot.zbd_.GetFreeSpace() >> 30;
-      ReportGeneral(ZENFS_LABEL(FREE_SPACE, SIZE), free_space_gb);
-    }
+
+  virtual void ReportSnapshot(const ZenFSSnapshot& snapshot) {
+    uint64_t free_space_gb = snapshot.zbd_.free_space >> 30;
+    ReportGeneral(ZENFS_LABEL(FREE_SPACE, SIZE), free_space_gb);
     // Report anything you care about.
   }
 

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -859,9 +859,10 @@ void ZonedBlockDevice::SetZoneDeferredStatus(IOStatus status) {
   }
 }
 
-void ZonedBlockDevice::GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot,
-                                       const ZenFSSnapshotOptions &options) {
-  for (auto &zone : io_zones) snapshot.emplace_back(*zone, options);
+void ZonedBlockDevice::GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot) {
+  for (auto *zone : io_zones) {
+    snapshot.emplace_back(*zone);
+  }
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -154,8 +154,7 @@ class ZonedBlockDevice {
 
   std::shared_ptr<ZenFSMetrics> GetMetrics() { return metrics_; }
 
-  void GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot,
-                       const ZenFSSnapshotOptions &options);
+  void GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot);
 
  private:
   std::string ErrorToString(int err);


### PR DESCRIPTION
1. Remove unnecessary abstraction, reduce complexity
2. Add extents to file mapping, help us find filename by extent id (useful for collaborative GC)

Signed-off-by: Kuankuan Guo <guokuankuan@bytedance.com>