### PR TITLE
fs: add extent migration API for better collaborative GC

### DIFF
--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -73,6 +73,9 @@ class ZoneFile {
 
   MetadataWriter* metadata_writer_ = NULL;
 
+  std::mutex writer_mtx_;
+  std::atomic<int> readers_{0};
+
  public:
   static const int SPARSE_HEADER_SIZE = 8;
 
@@ -96,6 +99,7 @@ class ZoneFile {
   void SetFileModificationTime(time_t mt);
   uint64_t GetFileSize();
   void SetFileSize(uint64_t sz);
+  void ClearExtents();
 
   uint32_t GetBlockSize() { return zbd_->GetBlockSize(); }
   ZonedBlockDevice* GetZbd() { return zbd_; }
@@ -115,9 +119,12 @@ class ZoneFile {
   void EncodeSnapshotTo(std::string* output) { EncodeTo(output, 0); };
   void EncodeJson(std::ostream& json_stream);
   void MetadataSynced() { nr_synced_extents_ = extents_.size(); };
+  void MetadataUnsynced() { nr_synced_extents_ = 0; };
+
+  IOStatus MigrateData(uint64_t offset, uint32_t length, Zone* target_zone);
 
   Status DecodeFrom(Slice* input);
-  Status MergeUpdate(std::shared_ptr<ZoneFile> update);
+  Status MergeUpdate(std::shared_ptr<ZoneFile> update, bool replace);
 
   uint64_t GetID() { return file_id_; }
   size_t GetUniqueId(char* id, size_t max_size);
@@ -130,6 +137,8 @@ class ZoneFile {
 
   IOStatus Recover();
 
+  void ReplaceExtentList(std::vector<ZoneExtent*> new_list);
+
  private:
   void ReleaseActiveZone();
   void SetActiveZone(Zone* zone);
@@ -139,6 +148,32 @@ class ZoneFile {
   std::shared_ptr<ZenFSMetrics> GetZBDMetrics() { return zbd_->GetMetrics(); }
   IOType GetIOType() const { return IOType::kUnknown; }
   IOStatus RecoverSparseExtents(uint64_t start, uint64_t end, Zone* zone);
+
+ public:
+  class ReadLock {
+   public:
+    ReadLock(ZoneFile* zfile) : zfile_(zfile) {
+      zfile_->writer_mtx_.lock();
+      zfile_->readers_++;
+      zfile_->writer_mtx_.unlock();
+    }
+    ~ReadLock() { zfile_->readers_--; }
+
+   private:
+    ZoneFile* zfile_;
+  };
+  class WriteLock {
+   public:
+    WriteLock(ZoneFile* zfile) : zfile_(zfile) {
+      zfile_->writer_mtx_.lock();
+      while (zfile_->readers_ > 0) {
+      }
+    }
+    ~WriteLock() { zfile_->writer_mtx_.unlock(); }
+
+   private:
+    ZoneFile* zfile_;
+  };
 };
 
 class ZonedWritableFile : public FSWritableFile {

--- a/fs/snapshot.h
+++ b/fs/snapshot.h
@@ -18,15 +18,12 @@ namespace ROCKSDB_NAMESPACE {
 struct ZenFSSnapshotOptions {
   // Global zoned device stats info
   bool zbd_ = 0;
-
   // Per zone stats info
   bool zone_ = 0;
-
   // Get all file->extents & extent->file mappings
   bool zone_file_ = 0;
-
   bool trigger_report_ = 0;
-
+  bool log_garbage_ = 0;
   bool as_lock_free_as_possible_ = 1;
 };
 

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -100,6 +100,10 @@ class ZonedBlockDevice {
   std::mutex zone_deferred_status_mutex_;
   IOStatus zone_deferred_status_;
 
+  std::condition_variable migrate_resource_;
+  std::mutex migrate_zone_mtx_;
+  std::atomic<bool> migrating_{false};
+
   unsigned int max_nr_active_io_zones_;
   unsigned int max_nr_open_io_zones_;
 
@@ -157,6 +161,13 @@ class ZonedBlockDevice {
 
   void GetZoneSnapshot(std::vector<ZoneSnapshot> &snapshot);
 
+  int DirectRead(char *buf, uint64_t offset, int n);
+
+  IOStatus ReleaseMigrateZone(Zone *zone);
+
+  IOStatus TakeMigrateZone(Zone **out_zone, Env::WriteLifeTimeHint lifetime,
+                           uint32_t min_capacity);
+
  private:
   std::string ErrorToString(int err);
   IOStatus GetZoneDeferredStatus();
@@ -165,7 +176,8 @@ class ZonedBlockDevice {
   IOStatus ApplyFinishThreshold();
   IOStatus FinishCheapestIOZone();
   IOStatus GetBestOpenZoneMatch(Env::WriteLifeTimeHint file_lifetime,
-                                unsigned int *best_diff_out, Zone **zone_out);
+                                unsigned int *best_diff_out, Zone **zone_out,
+                                uint32_t min_capacity = 0);
   IOStatus AllocateEmptyZone(Zone **zone_out);
 };
 


### PR DESCRIPTION
Please merge this PR first: https://github.com/westerndigitalcorporation/zenfs/pull/122

Please resolve this issue first: https://github.com/westerndigitalcorporation/zenfs/issues/124#issue-1089722934

NOTE:
The latest master branch has a significant performance drawback caused by the `inlined extent header` feature, we should first resolve that problem.


For non KV separation RocksDB, the default GC may work relatively well in most cases.

But for BlobDB(RocksDB's KV separation implement) and TerarkDB, the key files and value files don't have a predictable lifetime like before.

Thus the RocksDB layer's GC could be quite useless in these cases (We could meet 30%~50% garbage when running out of space).  And also, for heavy write throughput, non-kv separation implement could also run out of space much earlier than we expected.

So, a collaborative strategy is required, and we need the following APIs:

1. GetZenFSSnapshot (Provided by a previous PR)
Helps RocksDB identify when files should be collected during compaction, it can understand the lower level extent distribution and garbage distribution.

2. MigrateExtent (**This PR**)
- RocksDB cannot do its GC as efficiently as we expected and we don't want to change too much of RocksDB's compaction strategy (which may lead to unexpected performance drawbacks).
- So, for those zones with the highest garbage ratio (e.g. > 80%), we could simply migrate the extents within it and reset those zones after migration.
- By doing this, we can almost stable our disk-layer garbage ratio 



Signed-off-by: Kuankuan Guo <guokuankuan@bytedance.com>