### PR TITLE
fs: build failure when compiling rocksdb in debug mode

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1144,6 +1144,7 @@ std::map<std::string, Env::WriteLifeTimeHint> ZenFS::GetWriteLifeTimeHints() {
   return hint_map;
 }
 
+#if !defined(NDEBUG) || defined(WITH_TERARKDB)
 static std::string GetLogFilename(std::string bdev) {
   std::ostringstream ss;
   time_t t = time(0);
@@ -1155,6 +1156,7 @@ static std::string GetLogFilename(std::string bdev) {
 
   return ss.str();
 }
+#endif
 
 Status NewZenFS(FileSystem** fs, const std::string& bdevname,
                 std::shared_ptr<ZenFSMetrics> metrics) {
@@ -1166,7 +1168,7 @@ Status NewZenFS(FileSystem** fs, const std::string& bdevname,
   //
   // TODO(guokuankuan@bytedance.com) We need to figure out how to reuse
   // RocksDB's logger in the future.
-#if defined(NDEBUG) || defined(WITH_TERARKDB)
+#if !defined(NDEBUG) || defined(WITH_TERARKDB)
   s = Env::Default()->NewLogger(GetLogFilename(bdevname), &logger);
   if (!s.ok()) {
     fprintf(stderr, "ZenFS: Could not create logger");


### PR DESCRIPTION
When building with DEBUG_LEVEL=1 with below command,
"make clean;DEBUG_LEVEL=1 ROCKSDB_PLUGINS=zenfs make -j48 db_bench db_stress ldb"
rocksdb compilation fails with error:
"error: ‘std::string rocksdb::GetLogFilename(std::string)’ defined but not used"

Current logic defines the function GetLogFileName() for all debug levels(0,1,2)
but uses it only when debug-level=0. So for debug builds it gets defined but
is not used, resulting in the error. Also logs are enabled in production
builds now. Related to 7f8392e.

Define it such that is enabled for (debug-level > 0) OR when TERARKDB is defined.

Signed-off-by: Aravind Ramesh <Aravind.Ramesh@wdc.com>