### PR TITLE
fs: increase zone extent size to 64 bits

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -281,7 +281,7 @@ void ZenFS::LogFiles() {
          zFile->IsSparse());
     for (unsigned int i = 0; i < extents.size(); i++) {
       ZoneExtent* extent = extents[i];
-      Info(logger_, "          Extent %u {start=0x%lx, zone=%u, len=%u} ", i,
+      Info(logger_, "          Extent %u {start=0x%lx, zone=%u, len=%lu} ", i,
            extent->start_,
            (uint32_t)(extent->zone_->start_ / zbd_->GetZoneSize()),
            extent->length_);

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -42,7 +42,7 @@ class Superblock {
  public:
   const uint32_t MAGIC = 0x5a454e46; /* ZENF */
   const uint32_t ENCODED_SIZE = 512;
-  const uint32_t CURRENT_SUPERBLOCK_VERSION = 1;
+  const uint32_t CURRENT_SUPERBLOCK_VERSION = 2;
   const uint32_t DEFAULT_FLAGS = 0;
 
   Superblock() {}

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -28,7 +28,7 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-ZoneExtent::ZoneExtent(uint64_t start, uint32_t length, Zone* zone)
+ZoneExtent::ZoneExtent(uint64_t start, uint64_t length, Zone* zone)
     : start_(start), length_(length), zone_(zone) {}
 
 Status ZoneExtent::DecodeFrom(Slice* input) {
@@ -36,13 +36,13 @@ Status ZoneExtent::DecodeFrom(Slice* input) {
     return Status::Corruption("ZoneExtent", "Error: length missmatch");
 
   GetFixed64(input, &start_);
-  GetFixed32(input, &length_);
+  GetFixed64(input, &length_);
   return Status::OK();
 }
 
 void ZoneExtent::EncodeTo(std::string* output) {
   PutFixed64(output, start_);
-  PutFixed32(output, length_);
+  PutFixed64(output, length_);
 }
 
 void ZoneExtent::EncodeJson(std::ostream& json_stream) {

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -30,10 +30,10 @@ namespace ROCKSDB_NAMESPACE {
 class ZoneExtent {
  public:
   uint64_t start_;
-  uint32_t length_;
+  uint64_t length_;
   Zone* zone_;
 
-  explicit ZoneExtent(uint64_t start, uint32_t length, Zone* zone);
+  explicit ZoneExtent(uint64_t start, uint64_t length, Zone* zone);
   Status DecodeFrom(Slice* input);
   void EncodeTo(std::string* output);
   void EncodeJson(std::ostream& json_stream);


### PR DESCRIPTION
Increase the zone extent size to be 64 bits instead of 32, to
support very large file sizes in large zones.

This change is not backward-compatible with the current on-disk
format, so we need to step up the version.

Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>