### PR TITLE
 fs,util: Fix a bug where zone locks are not handled correctly

### DIFF
--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -2,9 +2,11 @@ on:
   push:
     branches:
     - master
+    - 1.0
   pull_request:
     branches:
     - master
+    - 1.0
 name: Lint
 jobs:
   clang-format:

--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run clang-format style check for C/C++ programs.
-      uses: jidicula/clang-format-action@v3.4.0
+      uses: jidicula/clang-format-action@v4.4.1
       with:
         clang-format-version: '11'
         check-path: .

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -2,9 +2,11 @@ on:
   push:
     branches:
     - master
+    - 1.0
   pull_request:
     branches:
     - master
+    - 1.0
 name: Smoke Test
 jobs:
   smoke-test:

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -373,6 +373,6 @@ class ZenFS : public FileSystemWrapper {
 Status NewZenFS(
     FileSystem** fs, const std::string& bdevname,
     std::shared_ptr<ZenFSMetrics> metrics = std::make_shared<NoZenFSMetrics>());
-std::map<std::string, std::string> ListZenFileSystems();
+Status ListZenFileSystems(std::map<std::string, std::string>& out_list);
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -278,7 +278,13 @@ int zenfs_tool_df() {
 }
 
 int zenfs_tool_lsuuid() {
-  std::map<std::string, std::string> zenFileSystems = ListZenFileSystems();
+  std::map<std::string, std::string> zenFileSystems;
+  Status s = ListZenFileSystems(zenFileSystems);
+  if (!s.ok()) {
+    fprintf(stderr, "Failed to enumerate file systems: %s",
+            s.ToString().c_str());
+    return 1;
+  }
 
   for (const auto &p : zenFileSystems)
     fprintf(stdout, "%s\t%s\n", p.first.c_str(), p.second.c_str());


### PR DESCRIPTION
Change signature of `ListZenFileSystems` to return status by value and file
system list by reference.

Reported-by: Mohit Joshi <mohit.joshi@percona.com>
Reported-by: Yura Sorokin <yura.sorokin@percona.com>
Signed-off-by: Andreas Hindborg <andreas.hindborg@wdc.com>
