### PR TITLE
fix: Change `used_capacity` to unsigned

### DIFF
--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #if !defined(ROCKSDB_LITE) && defined(OS_LINUX)
 
 #include <errno.h>
@@ -46,7 +47,7 @@ class Zone {
   uint64_t max_capacity_;
   uint64_t wp_;
   Env::WriteLifeTimeHint lifetime_;
-  std::atomic<long> used_capacity_;
+  std::atomic<uint64_t> used_capacity_;
 
   IOStatus Reset();
   IOStatus Finish();


### PR DESCRIPTION
`Zone::used_capacity_` is signed while `ZoneExtent::length_` is unsigned. This
causes a comparison problem in an assertion. There is no reason for
`used_capacity_` to be signed. This patch changes `Zone::used_capacity_` to
unsigned.

With gcc-9.3.0:
```text
In file included from plugin/zenfs/fs/io_zenfs.cc:11:
plugin/zenfs/fs/io_zenfs.cc: In destructor ‘virtual rocksdb::ZoneFile::~ZoneFile()’:
plugin/zenfs/fs/io_zenfs.cc:243:41: error: comparison of integer expressions of different signedness: ‘std::__atomic_base<long int>::__int_type’ {aka ‘long int’} and ‘uint64_t’ {aka ‘long unsigned int’} [-Werror=sign-compare]
  243 |     assert(zone && zone->used_capacity_ >= (*e)->length_);
      |                    ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make: *** [Makefile:2334: plugin/zenfs/fs/io_zenfs.o] Error 1
```