### PR TITLE
utils: strip debug symbols from zenfs utility binary

### DIFF
--- a/util/Makefile
+++ b/util/Makefile
@@ -4,6 +4,7 @@ TARGET = zenfs
 
 CC ?= gcc
 CXX ?= g++
+OBJCOPY ?= objcopy
 
 CXXFLAGS = $(shell pkg-config --cflags rocksdb)
 LIBS = $(shell pkg-config --static --libs rocksdb)
@@ -11,10 +12,16 @@ LIBS = $(shell pkg-config --static --libs rocksdb)
 CXXFLAGS +=  $(EXTRA_CXXFLAGS)
 LDFLAGS +=  $(EXTRA_LDFLAGS)
 
-all: $(TARGET)
+all: $(TARGET) $(TARGET).dbg
+
+$(TARGET).dbg: $(TARGET)
+	@$(OBJCOPY) --only-keep-debug $(TARGET) $(TARGET).dbg
+	@$(OBJCOPY) --strip-all $(TARGET)
+
+debug: $(TARGET)
 
 $(TARGET): $(TARGET).cc
-	$(CXX) $(CXXFLAGS) -o $(TARGET) $< $(LIBS) $(LDFLAGS)
+	$(CXX) $(CXXFLAGS) -g -o $(TARGET) $< $(LIBS) $(LDFLAGS)
 
 clean:
-	$(RM) $(TARGET)
+	$(RM) $(TARGET) $(TARGET).dbg


### PR DESCRIPTION
zenfs utility is built with debug symbols, causing it to go more than
210MB in size. Modify the Makefile to compile it without the debug symbols
for normal build. This reduces the size from ~210MB to ~6MB.

Added a debug target so that "make debug", would still compile the binary
with the symbols. Now zenfs utility can be built in release mode by using
the command "make" or "make all", it can be built in debug mode using
"make debug".

Signed-off-by: Aravind Ramesh<Aravind.Ramesh@wdc.com>