### PR TITLE
Safer migration delete check

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -441,9 +441,9 @@ IOStatus ZenFS::SyncFileMetadata(ZoneFile* zoneFile, bool replace) {
 
   std::lock_guard<std::mutex> lock(files_mtx_);
 
-  if (GetFileInternal(zoneFile->GetFilename()) == nullptr) {
-    Info(logger_, "File %s doesn't exist, skip sync file metadata!",
-         zoneFile->GetFilename().data());
+  if (zoneFile->IsDeleted()) {
+    Info(logger_, "File %s has been deleted, skip sync file metadata!",
+         zoneFile->GetFilename().c_str());
     return IOStatus::OK();
   }
 
@@ -1385,9 +1385,10 @@ IOStatus ZenFS::MigrateFileExtents(
   IOStatus s = IOStatus::OK();
   Info(logger_, "MigrateFileExtents, fname: %s, extent count: %lu",
        fname.data(), migrate_exts.size());
+
   // The file may be deleted by other threads, better double check.
   auto zfile = GetFile(fname);
-  if (zfile == nullptr || zfile->IsOpenForWR()) {
+  if (zfile == nullptr || zfile->IsDeleted() || zfile->IsOpenForWR()) {
     return IOStatus::OK();
   }
 

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -497,6 +497,8 @@ IOStatus ZenFS::DeleteFile(std::string fname) {
         /* Failed to persist the delete, return to a consistent state */
         files_.insert(std::make_pair(fname.c_str(), zoneFile));
       } else {
+        /* Mark up the file as deleted so it won't be migrated by GC */
+        zoneFile->SetDeleted();
         zoneFile.reset();
       }
     } else {

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -70,6 +70,7 @@ class ZoneFile {
   bool open_for_wr_ = false;
   time_t m_time_;
   bool is_sparse_ = false;
+  bool is_deleted_ = false;
 
   MetadataWriter* metadata_writer_ = NULL;
 
@@ -145,8 +146,10 @@ class ZoneFile {
   IOStatus CloseActiveZone();
 
  public:
-  std::shared_ptr<ZenFSMetrics> GetZBDMetrics() { return zbd_->GetMetrics(); }
-  IOType GetIOType() const { return io_type_; }
+  std::shared_ptr<ZenFSMetrics> GetZBDMetrics() { return zbd_->GetMetrics(); };
+  IOType GetIOType() const { return io_type_; };
+  bool IsDeleted() const { return is_deleted_; };
+  void SetDeleted() { is_deleted_ = true; };
   IOStatus RecoverSparseExtents(uint64_t start, uint64_t end, Zone* zone);
 
  public:


### PR DESCRIPTION
Files may be deleted or renamed at any time we migrate files in
a garabage-collection thread. By checking IsDeleted rather
than checking if the file name exists, we make sure that
we we won't write spurious update records for a file
that is deleted and/or renamed while being migrated.
