### PR TITLE
metrics: add more metrics explanition comments & refine metrics

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -19,7 +19,6 @@
 #include <utility>
 #include <vector>
 
-#include "metrics_sample.h"
 #include "rocksdb/utilities/object_registry.h"
 #include "snapshot.h"
 #include "util/coding.h"
@@ -329,9 +328,9 @@ IOStatus ZenFS::RollMetaZoneLocked() {
   Zone* new_meta_zone = nullptr;
   IOStatus s;
 
-  ZenFSMetricsLatencyGuard guard(zbd_->GetMetrics(), ZENFS_LABEL(ROLL, LATENCY),
+  ZenFSMetricsLatencyGuard guard(zbd_->GetMetrics(), ZENFS_ROLL_LATENCY,
                                  Env::Default());
-  zbd_->GetMetrics()->ReportQPS(ZENFS_LABEL(ROLL, QPS), 1);
+  zbd_->GetMetrics()->ReportQPS(ZENFS_ROLL_QPS, 1);
 
   IOStatus status = zbd_->AllocateMetaZone(&new_meta_zone);
   if (!status.ok()) return status;
@@ -436,9 +435,8 @@ IOStatus ZenFS::SyncFileMetadata(ZoneFile* zoneFile, bool replace) {
   std::string fileRecord;
   std::string output;
   IOStatus s;
-  ZenFSMetricsLatencyGuard guard(
-      zbd_->GetMetrics(), ZENFS_LABEL(META_SYNC, LATENCY), Env::Default());
-
+  ZenFSMetricsLatencyGuard guard(zbd_->GetMetrics(), ZENFS_META_SYNC_LATENCY,
+                                 Env::Default());
   std::lock_guard<std::mutex> lock(files_mtx_);
 
   if (GetFileInternal(zoneFile->GetFilename()) == nullptr) {

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -310,9 +310,9 @@ ZoneExtent* ZoneFile::GetExtent(uint64_t file_offset, uint64_t* dev_offset) {
 
 IOStatus ZoneFile::PositionedRead(uint64_t offset, size_t n, Slice* result,
                                   char* scratch, bool direct) {
-  ZenFSMetricsLatencyGuard guard(zbd_->GetMetrics(), ZENFS_LABEL(READ, LATENCY),
+  ZenFSMetricsLatencyGuard guard(zbd_->GetMetrics(), ZENFS_READ_LATENCY,
                                  Env::Default());
-  zbd_->GetMetrics()->ReportQPS(ZENFS_LABEL(READ, QPS), 1);
+  zbd_->GetMetrics()->ReportQPS(ZENFS_READ_QPS, 1);
 
   ReadLock lck(this);
 
@@ -724,13 +724,12 @@ IOStatus ZonedWritableFile::DataSync() {
 IOStatus ZonedWritableFile::Fsync(const IOOptions& /*options*/,
                                   IODebugContext* /*dbg*/) {
   IOStatus s;
-  ZenFSMetricsLatencyGuard guard(
-      zoneFile_->GetZBDMetrics(),
-      zoneFile_->GetIOType() == IOType::kWAL
-          ? ZENFS_LABEL_DETAILED(SYNC, WAL, LATENCY)
-          : ZENFS_LABEL_DETAILED(SYNC, NON_WAL, LATENCY),
-      Env::Default());
-  zoneFile_->GetZBDMetrics()->ReportQPS(ZENFS_LABEL(SYNC, QPS), 1);
+  ZenFSMetricsLatencyGuard guard(zoneFile_->GetZBDMetrics(),
+                                 zoneFile_->GetIOType() == IOType::kWAL
+                                     ? ZENFS_WAL_SYNC_LATENCY
+                                     : ZENFS_NON_WAL_SYNC_LATENCY,
+                                 Env::Default());
+  zoneFile_->GetZBDMetrics()->ReportQPS(ZENFS_SYNC_QPS, 1);
 
   s = DataSync();
   if (!s.ok()) return s;
@@ -816,14 +815,13 @@ IOStatus ZonedWritableFile::Append(const Slice& data,
                                    const IOOptions& /*options*/,
                                    IODebugContext* /*dbg*/) {
   IOStatus s;
-  ZenFSMetricsLatencyGuard guard(
-      zoneFile_->GetZBDMetrics(),
-      zoneFile_->GetIOType() == IOType::kWAL
-          ? ZENFS_LABEL_DETAILED(WRITE, WAL, LATENCY)
-          : ZENFS_LABEL_DETAILED(WRITE, NON_WAL, LATENCY),
-      Env::Default());
-  zoneFile_->GetZBDMetrics()->ReportQPS(ZENFS_LABEL(WRITE, QPS), 1);
-  zoneFile_->GetZBDMetrics()->ReportThroughput(ZENFS_LABEL(WRITE, THROUGHPUT),
+  ZenFSMetricsLatencyGuard guard(zoneFile_->GetZBDMetrics(),
+                                 zoneFile_->GetIOType() == IOType::kWAL
+                                     ? ZENFS_WAL_WRITE_LATENCY
+                                     : ZENFS_NON_WAL_WRITE_LATENCY,
+                                 Env::Default());
+  zoneFile_->GetZBDMetrics()->ReportQPS(ZENFS_WRITE_QPS, 1);
+  zoneFile_->GetZBDMetrics()->ReportThroughput(ZENFS_WRITE_THROUGHPUT,
                                                data.size());
 
   if (buffered) {
@@ -842,6 +840,14 @@ IOStatus ZonedWritableFile::PositionedAppend(const Slice& data, uint64_t offset,
                                              const IOOptions& /*options*/,
                                              IODebugContext* /*dbg*/) {
   IOStatus s;
+  ZenFSMetricsLatencyGuard guard(zoneFile_->GetZBDMetrics(),
+                                 zoneFile_->GetIOType() == IOType::kWAL
+                                     ? ZENFS_WAL_WRITE_LATENCY
+                                     : ZENFS_NON_WAL_WRITE_LATENCY,
+                                 Env::Default());
+  zoneFile_->GetZBDMetrics()->ReportQPS(ZENFS_WRITE_QPS, 1);
+  zoneFile_->GetZBDMetrics()->ReportThroughput(ZENFS_WRITE_THROUGHPUT,
+                                               data.size());
 
   if (offset != wp) {
     assert(false);

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,5 +1,5 @@
 zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
-zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/version.h fs/metrics.h fs/metrics_sample.h fs/snapshot.h
+zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/version.h fs/metrics.h fs/snapshot.h
 zenfs_LDFLAGS = -lzbd -u zenfs_filesystem_reg
 
 ZENFS_ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
- The previous metrics implementation is not well documented
- Some metrics helper functions are not necessary (e.g. `ZENFS_LABEL` confuses readers)
- Add QPS and throughput trace for ZoneFile::PositionedAppend
- Add Throughput trace for Zone::Append

Signed-off-by: Kuankuan Guo <guokuankuan@bytedance.com>