### PR TITLE
Add/improve metadata format instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,26 @@ This is done with the zenfs utility, using the mkfs command:
 ./plugin/zenfs/util/zenfs mkfs --zbd=<zoned block device> --aux_path=<path to store LOG and LOCK files>
 ```
 
+## ZenFS on-disk file formats
+
+ZenFS Version 1.0.0 and earlier uses version 1 of the on-disk format.
+ZenFS Version 2.0.0 introduces breaking on-disk-format changes (inline extents, support for zones larged than 4GB).
+
+To migrate between different versions of the on-disk file format, use the zenfs backup/restore commands.
+
+```
+# Backup the disk contents to the host file system using the version of zenfs that was used to store the current database
+./plugin/zenfs/util/zenfs backup --path=<path to store backup> --zbd=<zoned block device>
+
+# Switch to the new version of ZenFS you want to use (e.g 1.0.2 -> 2.0.0), rebuild and create a new file system
+# Remove the current aux folder if needed.
+./plugin/zenfs/util/zenfs mkfs --force --zbd=<zoned block device> --aux_path=<path to store LOG and LOCK files>
+
+# Restore the database files to the new version of the file system
+./plugin/zenfs/util/zenfs restore --path=<path to backup> --zbd=<zoned block device>
+
+```
+
 ## Testing with db_bench
 
 To instruct db_bench to use zenfs on a specific zoned block device, the --fs_uri parameter is used.

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -54,8 +54,13 @@ Status Superblock::DecodeFrom(Slice* input) {
 
   if (magic_ != MAGIC)
     return Status::Corruption("ZenFS Superblock", "Error: Magic missmatch");
-  if (superblock_version_ != CURRENT_SUPERBLOCK_VERSION)
-    return Status::Corruption("ZenFS Superblock", "Error: Version missmatch");
+  if (superblock_version_ != CURRENT_SUPERBLOCK_VERSION) {
+    return Status::Corruption(
+        "ZenFS Superblock",
+        "Error: Incompatible ZenFS on-disk format version, "
+        "please migrate data or switch to previously used ZenFS version. "
+        "See the ZenFS README for instructions.");
+  }
 
   return Status::OK();
 }


### PR DESCRIPTION
This PR introduces a more instructive error message when trying to mount an incompatible zenfs on-disk format.

It also adds a section in the README describing the different versions briefly and how to migrate between them.