### PR TITLE
Make zenfs compatible with latest plugin registration API

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -995,8 +995,6 @@ Status ZenFS::RecoverFrom(ZenMetaLog* log) {
     return Status::NotFound("ZenFS", "No snapshot found");
 }
 
-#define ZENV_URI_PATTERN "zenfs://"
-
 /* Mount the filesystem by recovering form the latest valid metadata zone */
 Status ZenFS::Mount(bool readonly) {
   std::vector<Zone*> metazones = zbd_->GetMetaZones();
@@ -1464,9 +1462,17 @@ IOStatus ZenFS::MigrateFileExtents(
 extern "C" FactoryFunc<FileSystem> zenfs_filesystem_reg;
 
 FactoryFunc<FileSystem> zenfs_filesystem_reg =
+#if (ROCKSDB_MAJOR < 6) || (ROCKSDB_MAJOR <= 6 && ROCKSDB_MINOR < 28)
     ObjectLibrary::Default()->Register<FileSystem>(
         "zenfs://.*", [](const std::string& uri, std::unique_ptr<FileSystem>* f,
                          std::string* errmsg) {
+#else
+    ObjectLibrary::Default()->AddFactory<FileSystem>(
+        ObjectLibrary::PatternEntry("zenfs", false)
+            .AddSeparator("://"), /* "zenfs://.+" */
+        [](const std::string& uri, std::unique_ptr<FileSystem>* f,
+           std::string* errmsg) {
+#endif
           std::string devID = uri;
           FileSystem* fs = nullptr;
           Status s;


### PR DESCRIPTION
Upstream RocksDB has changed the filesystem registration API.
Add support for the new API and enable compatibility with
older versions of RocksDB (version < 7 ) by passing a compile time
flag (ZENFS_USE_OLD_REGISTRATION_API).

Example(building zenfs with rocksdb 6.x.x after this commit)

CFLAGS=-DZENFS_USE_OLD_REGISTRATION_API ROCKSDB_PLUGINS="zenfs" make db_bench