### PR TITLE
fs: Fix a bug where `ZonedWritableFile` bufferes are not flushed

### DIFF
--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -704,7 +704,7 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
 }
 
 ZonedWritableFile::~ZonedWritableFile() {
-  IOStatus s = zoneFile_->CloseWR();
+  IOStatus s = CloseInternal();
   if (buffered) free(sparse_buffer);
 
   if (!s.ok()) {
@@ -776,6 +776,14 @@ IOStatus ZonedWritableFile::RangeSync(uint64_t offset, uint64_t nbytes,
 
 IOStatus ZonedWritableFile::Close(const IOOptions& /*options*/,
                                   IODebugContext* /*dbg*/) {
+  return CloseInternal();
+}
+
+IOStatus ZonedWritableFile::CloseInternal() {
+  if (!zoneFile_->IsOpenForWR()) {
+    return IOStatus::OK();
+  }
+
   IOStatus s = DataSync();
   if (!s.ok()) return s;
 

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -226,6 +226,7 @@ class ZonedWritableFile : public FSWritableFile {
   IOStatus BufferedWrite(const Slice& data);
   IOStatus FlushBuffer();
   IOStatus DataSync();
+  IOStatus CloseInternal();
 
   bool buffered;
   char* sparse_buffer;


### PR DESCRIPTION
If a `ZonedWritableFile` is destroyed without being closed, buffered contents
are not flushed to disk. This patch activates close procedure on object
destruction to fix the problem.