### PR TITLE
fs: drop empty-file assertion for writable files

### DIFF
--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -674,7 +674,6 @@ ZonedWritableFile::ZonedWritableFile(ZonedBlockDevice* zbd, bool _buffered,
                                      std::shared_ptr<ZoneFile> zoneFile,
                                      MetadataWriter* metadata_writer) {
   wp = zoneFile->GetFileSize();
-  assert(wp == 0);
 
   buffered = _buffered;
   block_sz = zbd->GetBlockSize();


### PR DESCRIPTION
We do allow that files can be re-opened for appending
(ReopenWritableFile), so drop the assertion that the
file is empty when creating a new writable file.

Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>