### PR TITLE
io: fix wrong assertion condition

### DIFF
--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -1035,7 +1035,7 @@ IOStatus ZoneFile::MigrateData(uint64_t offset, uint32_t length,
   uint32_t read_sz = step;
   int block_sz = zbd_->GetBlockSize();
 
-  assert(offset % block_sz != 0);
+  assert(offset % block_sz == 0);
   if (offset % block_sz != 0) {
     return IOStatus::IOError("MigrateData offset is not aligned!\n");
   }


### PR DESCRIPTION
This issue didn't raise up because we always build with RelWithDebInfo, never tested in a debug mode....
```
assert(offset % block_sz != 0);
```

Signed-off-by: Kuankuan Guo <guokuankuan@bytedance.com>