### PR TITLE
fs: Add LinkFile api support to ZenFS.

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -860,6 +860,25 @@ IOStatus ZenFS::LinkFile(const std::string& fname, const std::string& lname,
   return s;
 }
 
+IOStatus ZenFS::NumFileLinks(const std::string& fname, const IOOptions& options,
+                             uint64_t* nr_links, IODebugContext* dbg) {
+  std::shared_ptr<ZoneFile> src_file(nullptr);
+  IOStatus s;
+
+  Debug(logger_, "NumFileLinks: %s\n", fname.c_str());
+  {
+    std::lock_guard<std::mutex> lock(files_mtx_);
+
+    src_file = GetFileNoLock(fname);
+    if (src_file != nullptr) {
+      *nr_links = (uint64_t)src_file->GetNrLinks();
+      return IOStatus::OK();
+    }
+  }
+  s = target()->NumFileLinks(ToAuxPath(fname), options, nr_links, dbg);
+  return s;
+}
+
 void ZenFS::EncodeSnapshotTo(std::string* output) {
   std::map<std::string, std::shared_ptr<ZoneFile>>::iterator it;
   std::string files_string;

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -176,7 +176,7 @@ class ZenFS : public FileSystemWrapper {
 
   void EncodeSnapshotTo(std::string* output);
   void EncodeFileDeletionTo(std::shared_ptr<ZoneFile> zoneFile,
-                            std::string* output);
+                            std::string* output, std::string linkf);
 
   Status DecodeSnapshotFrom(Slice* input);
   Status DecodeFileUpdateFrom(Slice* slice, bool replace = false);
@@ -266,6 +266,10 @@ class ZenFS : public FileSystemWrapper {
   virtual IOStatus DeleteFile(const std::string& fname,
                               const IOOptions& options,
                               IODebugContext* dbg) override;
+  virtual IOStatus LinkFile(const std::string& fname, const std::string& lname,
+                            const IOOptions& options,
+                            IODebugContext* dbg) override;
+
   IOStatus GetFileSize(const std::string& f, const IOOptions& options,
                        uint64_t* size, IODebugContext* dbg) override;
   IOStatus RenameFile(const std::string& f, const std::string& t,
@@ -380,13 +384,6 @@ class ZenFS : public FileSystemWrapper {
       std::unique_ptr<MemoryMappedFileBuffer>* /*result*/) override {
     return IOStatus::NotSupported(
         "MemoryMappedFileBuffer is not implemented in ZenFS");
-  }
-
-  virtual IOStatus LinkFile(const std::string& /*src*/,
-                            const std::string& /*target*/,
-                            const IOOptions& /*options*/,
-                            IODebugContext* /*dbg*/) override {
-    return IOStatus::NotSupported("LinkFile is not supported in ZenFS");
   }
 
   virtual IOStatus NumFileLinks(const std::string& /*fname*/,

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -269,6 +269,9 @@ class ZenFS : public FileSystemWrapper {
   virtual IOStatus LinkFile(const std::string& fname, const std::string& lname,
                             const IOOptions& options,
                             IODebugContext* dbg) override;
+  virtual IOStatus NumFileLinks(const std::string& fname,
+                                const IOOptions& options, uint64_t* nr_links,
+                                IODebugContext* dbg) override;
 
   IOStatus GetFileSize(const std::string& f, const IOOptions& options,
                        uint64_t* size, IODebugContext* dbg) override;
@@ -384,14 +387,6 @@ class ZenFS : public FileSystemWrapper {
       std::unique_ptr<MemoryMappedFileBuffer>* /*result*/) override {
     return IOStatus::NotSupported(
         "MemoryMappedFileBuffer is not implemented in ZenFS");
-  }
-
-  virtual IOStatus NumFileLinks(const std::string& /*fname*/,
-                                const IOOptions& /*options*/,
-                                uint64_t* /*count*/,
-                                IODebugContext* /*dbg*/) override {
-    return IOStatus::NotSupported(
-        "Getting number of file links is not supported in ZenFS");
   }
 
   virtual IOStatus AreFilesSame(const std::string& /*first*/,

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -272,6 +272,10 @@ class ZenFS : public FileSystemWrapper {
   virtual IOStatus NumFileLinks(const std::string& fname,
                                 const IOOptions& options, uint64_t* nr_links,
                                 IODebugContext* dbg) override;
+  virtual IOStatus AreFilesSame(const std::string& fname,
+                                const std::string& link,
+                                const IOOptions& options, bool* res,
+                                IODebugContext* dbg) override;
 
   IOStatus GetFileSize(const std::string& f, const IOOptions& options,
                        uint64_t* size, IODebugContext* dbg) override;
@@ -387,13 +391,6 @@ class ZenFS : public FileSystemWrapper {
       std::unique_ptr<MemoryMappedFileBuffer>* /*result*/) override {
     return IOStatus::NotSupported(
         "MemoryMappedFileBuffer is not implemented in ZenFS");
-  }
-
-  virtual IOStatus AreFilesSame(const std::string& /*first*/,
-                                const std::string& /*second*/,
-                                const IOOptions& /*options*/, bool* /*res*/,
-                                IODebugContext* /*dbg*/) override {
-    return IOStatus::NotSupported("AreFilesSame is not supported in ZenFS");
   }
 
   void GetZenFSSnapshot(ZenFSSnapshot& snapshot,

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -55,6 +55,7 @@ class ZoneFile {
   ZonedBlockDevice* zbd_;
 
   std::vector<ZoneExtent*> extents_;
+  std::vector<std::string> linkfiles_;
 
   Zone* active_zone_;
   uint64_t extent_start_ = NO_EXTENT;
@@ -63,7 +64,6 @@ class ZoneFile {
   Env::WriteLifeTimeHint lifetime_;
   IOType io_type_; /* Only used when writing */
   uint64_t fileSize;
-  std::string filename_;
   uint64_t file_id_;
 
   uint32_t nr_synced_extents_ = 0;
@@ -80,8 +80,7 @@ class ZoneFile {
  public:
   static const int SPARSE_HEADER_SIZE = 8;
 
-  explicit ZoneFile(ZonedBlockDevice* zbd, std::string filename,
-                    uint64_t file_id_);
+  explicit ZoneFile(ZonedBlockDevice* zbd, uint64_t file_id_);
 
   virtual ~ZoneFile();
 
@@ -96,7 +95,6 @@ class ZoneFile {
   IOStatus SetWriteLifeTimeHint(Env::WriteLifeTimeHint lifetime);
   void SetIOType(IOType io_type);
   std::string GetFilename();
-  void Rename(std::string name);
   time_t GetFileModificationTime();
   void SetFileModificationTime(time_t mt);
   uint64_t GetFileSize();
@@ -140,6 +138,11 @@ class ZoneFile {
   IOStatus Recover();
 
   void ReplaceExtentList(std::vector<ZoneExtent*> new_list);
+  void AddLinkName(const std::string& linkfile);
+  IOStatus RemoveLinkName(const std::string& linkfile);
+  IOStatus RenameLink(const std::string& src, const std::string& dest);
+  uint32_t GetNrLinks() { return linkfiles_.size(); }
+  const std::vector<std::string>& GetLinkFiles() const { return linkfiles_; }
 
  private:
   void ReleaseActiveZone();


### PR DESCRIPTION
This api simulates posix hard link behavior.
It accepts the source-file and destination-file names, if the source file is
available, it creates an entry in the in-memory files_ map and also
updates the source-file's metadata about the newly linked file and
increments the link count for the source-file and persists this information
on disk.
File deletion ensures that as long as there are links associated to a file,
the file is not deleted on disk and only link specific metadata is updated
and persisted on disk.

Signed-off-by: Aravind Ramesh <aravind.ramesh@wdc.com>