### PR TITLE
Support RocksDB checkpointing

### DIFF
--- a/.github/workflows/long-performance-xfs.yaml
+++ b/.github/workflows/long-performance-xfs.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.29.3
+          ref: v7.0.2
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/long-performance.yaml
+++ b/.github/workflows/long-performance.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.29.3
+          ref: v7.0.2
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/mtr-test.yaml
+++ b/.github/workflows/mtr-test.yaml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: percona/percona-server
-          ref: Percona-Server-8.0.26-17
+          ref: Percona-Server-8.0.28-19
           path: harness/percona-context/percona-server
           submodules: true
       - name: Remove default zenfs

--- a/.github/workflows/rocks-nightly.yaml
+++ b/.github/workflows/rocks-nightly.yaml
@@ -12,7 +12,6 @@ jobs:
         rocksdb-ref:
           - main
           - 7.0.fb
-          - 6.29.fb
     steps:
       - name: Clean
         run: rm -rf ${GITHUB_WORKSPACE}/*

--- a/.github/workflows/short-performance-xfs.yaml
+++ b/.github/workflows/short-performance-xfs.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.29.3
+          ref: v7.0.2
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/short-performance.yaml
+++ b/.github/workflows/short-performance.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.29.3
+          ref: v7.0.2
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/smoke-test-debug.yaml
+++ b/.github/workflows/smoke-test-debug.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.29.3
+          ref: v7.0.2
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.29.3
+          ref: v7.0.2
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/zbdbench.yaml
+++ b/.github/workflows/zbdbench.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.29.3
+          ref: v7.0.2
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -197,6 +197,10 @@ class ZenFS : public FileSystemWrapper {
   /* Must hold files_mtx_ */
   std::shared_ptr<ZoneFile> GetFileNoLock(std::string fname);
   /* Must hold files_mtx_ */
+  void GetZenFSChildrenNoLock(const std::string& dir,
+                              bool include_grandchildren,
+                              std::vector<std::string>* result);
+  /* Must hold files_mtx_ */
   IOStatus GetChildrenNoLock(const std::string& dir, const IOOptions& options,
                              std::vector<std::string>* result,
                              IODebugContext* dbg);

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -204,6 +204,24 @@ class ZenFS : public FileSystemWrapper {
   IOStatus GetChildrenNoLock(const std::string& dir, const IOOptions& options,
                              std::vector<std::string>* result,
                              IODebugContext* dbg);
+
+  /* Must hold files_mtx_ */
+  IOStatus RenameChildNoLock(std::string const& source_dir,
+                             std::string const& dest_dir,
+                             std::string const& child, const IOOptions& options,
+                             IODebugContext* dbg);
+
+  /* Must hold files_mtx_ */
+  IOStatus RollbackAuxDirRenameNoLock(
+      const std::string& source_path, const std::string& dest_path,
+      const std::vector<std::string>& renamed_children,
+      const IOOptions& options, IODebugContext* dbg);
+
+  /* Must hold files_mtx_ */
+  IOStatus RenameAuxPathNoLock(const std::string& source_path,
+                               const std::string& dest_path,
+                               const IOOptions& options, IODebugContext* dbg);
+
   /* Must hold files_mtx_ */
   IOStatus RenameFileNoLock(const std::string& f, const std::string& t,
                             const IOOptions& options, IODebugContext* dbg);

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -236,6 +236,11 @@ class ZenFS : public FileSystemWrapper {
   IOStatus Repair();
 
   /* Must hold files_mtx_ */
+  IOStatus DeleteDirRecursiveNoLock(const std::string& d,
+                                    const IOOptions& options,
+                                    IODebugContext* dbg);
+
+  /* Must hold files_mtx_ */
   IOStatus IsDirectoryNoLock(const std::string& path, const IOOptions& options,
                              bool* is_dir, IODebugContext* dbg) {
     if (GetFileNoLock(path) != nullptr) {
@@ -368,6 +373,9 @@ class ZenFS : public FileSystemWrapper {
 
     return target()->DeleteDir(ToAuxPath(d), options, dbg);
   }
+
+  IOStatus DeleteDirRecursive(const std::string& d, const IOOptions& options,
+                              IODebugContext* dbg);
 
   // We might want to override these in the future
   IOStatus GetAbsolutePath(const std::string& db_path, const IOOptions& options,

--- a/util/zenfs.8
+++ b/util/zenfs.8
@@ -67,6 +67,10 @@ Delete a specified link or file.
 .B rename
 Rename a specified link or file.
 
+.TP
+.B rmdir
+Delete a specified directory. Can be forced with the '--force' flag.
+
 .SH OPTIONS
 
 .TP
@@ -126,6 +130,10 @@ Deletes an existing file or link specified in the path.
 .TP
 .B zenfs rename --zbd=nvme0n1 --src_file=rocksdbtest/000045.sst --dst_file=rocksdbtest/newname.sst
 Rename a specified file or link, if the destination file exist, delete it and rename.
+
+.TP
+.B zenfs rmdir --zbd=nvme0n1 --path=rocksdbtest/dbbench --force
+Deletes the directory specified by the path with all its contents.
 
 .SH AUTHOR
 .TP


### PR DESCRIPTION
These commits enable ZenFS to ZenFS checkpointing in RocksDB.
Renaming was fixed such that all ZenFS file names are renamed according to a directory rename.
The `force-rmdir` util command was introduced so that checkpoints can be deleted (which is also needed by the rocksdb.checkpoint MTR test case). 
Addresses jira issue WDCZEN-19.

Reported-by: Yura Sorokin <yura.sorokin@percona.com>
Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>