### PR TITLE
Use `pkg-config` for specifying dependencies.

### DIFF
--- a/.github/workflows/long-performance-xfs.yaml
+++ b/.github/workflows/long-performance-xfs.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.25.3
+          ref: v6.29.3
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/long-performance.yaml
+++ b/.github/workflows/long-performance.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.25.3
+          ref: v6.29.3
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/short-performance-xfs.yaml
+++ b/.github/workflows/short-performance-xfs.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.25.3
+          ref: v6.29.3
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/short-performance.yaml
+++ b/.github/workflows/short-performance.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.25.3
+          ref: v6.29.3
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/smoke-test-debug.yaml
+++ b/.github/workflows/smoke-test-debug.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.25.3
+          ref: v6.29.3
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.25.3
+          ref: v6.29.3
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/.github/workflows/zbdbench.yaml
+++ b/.github/workflows/zbdbench.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: facebook/rocksdb
-          ref: v6.25.3
+          ref: v6.29.3
           path: harness/rocksdb-context/rocksdb
       - name: Checkout zenfs
         uses: actions/checkout@v2

--- a/tests/smoke/0004_dbstress.sh
+++ b/tests/smoke/0004_dbstress.sh
@@ -4,7 +4,7 @@ source smoke/common.sh
 OPS_PER_THREAD=1000
 REOPENS=5
 
-DB_STRESS_PARAMS="--ops_per_thread=$OPS_PER_THREAD --reopen=$REOPENS $FS_PARAMS"
+DB_STRESS_PARAMS="--ops_per_thread=$OPS_PER_THREAD --reopen=$REOPENS --db=dbname $FS_PARAMS"
 
 echo "# Running db_stress with parameters: $DB_STRESS_PARAMS" > $TEST_OUT
 $TOOLS_DIR/db_stress $DB_STRESS_PARAMS >> $TEST_OUT

--- a/util/Makefile
+++ b/util/Makefile
@@ -6,8 +6,15 @@ CC ?= gcc
 CXX ?= g++
 OBJCOPY ?= objcopy
 
-CXXFLAGS = $(shell pkg-config --cflags rocksdb)
-LIBS = $(shell pkg-config --static --libs rocksdb)
+CXXFLAGS := $(shell pkg-config --cflags rocksdb)
+ifneq ($(.SHELLSTATUS),0)
+$(error pkg-config failed)
+endif
+
+LIBS := $(shell pkg-config --static --libs rocksdb)
+ifneq ($(.SHELLSTATUS),0)
+$(error pkg-config failed)
+endif
 
 CXXFLAGS +=  $(EXTRA_CXXFLAGS)
 LDFLAGS +=  $(EXTRA_LDFLAGS)

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,6 +1,6 @@
 zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
 zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/version.h fs/metrics.h fs/snapshot.h
-zenfs_LDFLAGS = -lzbd -u zenfs_filesystem_reg
+zenfs_LDFLAGS = -u zenfs_filesystem_reg
 
 ZENFS_ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
@@ -8,3 +8,5 @@ $(shell cd $(ZENFS_ROOT_DIR) && ./generate-version.sh)
 ifneq ($(.SHELLSTATUS),0)
 $(error Generating ZenFS version failed)
 endif
+
+zenfs_PKGCONFIG_REQUIRES = "libzbd >= 1.5.0"


### PR DESCRIPTION
Use `pkg-config` to specify dependencies for ZenFS plugin. Required support was added to RocksDB a while back.