### PR TITLE
fs: Improve debugability by enabling libzbd error logging in zenfs.

### DIFF
--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -237,6 +237,10 @@ IOStatus ZonedBlockDevice::Open(bool readonly, bool exclusive) {
   if (!readonly && !exclusive)
     return IOStatus::InvalidArgument("Write opens must be exclusive");
 
+  // Enable error logging in libzbd before using libzbd apis.
+  // Change to ZBD_LOG_DEBUG for more verbose logging.
+  zbd_set_log_level(ZBD_LOG_ERROR);
+
   /* The non-direct file descriptor acts as an exclusive-use semaphore */
   if (exclusive) {
     read_f_ = zbd_open(filename_.c_str(), O_RDONLY | O_EXCL, &info);


### PR DESCRIPTION
Addresses issue #84 and improves debugability by enabling libzbd error logging in zenfs. Currently there's no debug build, hence the error logging level is set to ZBD_LOG_ERROR. Can be changed to ZBD_LOG_DEBUG if needed.