### PR TITLE
test: Example integration test based on RocksDB gtest infrastructure

### DIFF
--- a/.github/workflows/gtest.yaml
+++ b/.github/workflows/gtest.yaml
@@ -1,0 +1,48 @@
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+name: Gtest
+jobs:
+  smoke-test:
+    runs-on: self-hosted
+    steps:
+      - name: Clean
+        run: rm -rf ${GITHUB_WORKSPACE}/*
+      - name: Checkout build scripts
+        run: git clone ~/harness.git
+      - name: Checkout zbdbench
+        uses: actions/checkout@v2
+        with:
+          repository: westerndigitalcorporation/zbdbench
+          ref: v0.1.1
+          path: harness/rocksdb-context/zbdbench
+      - name: Checkout rocksdb
+        uses: actions/checkout@v2
+        with:
+          repository: metaspace/rocksdb
+          ref: plugin-tests
+          path: harness/rocksdb-context/rocksdb
+      - name: Checkout zenfs
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          path: harness/rocksdb-context/rocksdb/plugin/zenfs
+      - name: Build docker image
+        run: cd harness && st -o logs/make-image -- make NO_VAGRANT=1 V=1 rocksdb-gtest-docker-image 
+      - name: Run smoke tests
+        run: cd harness && st --silent -o logs/make-gtest -- disk-select --disk 1TB -- make NO_VAGRANT=1 results/zenfs-gtest.xml 
+      - name: Collect Results
+        run: cd harness && make NO_VAGRANT=1 upload 
+        if: always()
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: harness/results/cover-report-*.tgz
+      - name: Remove images
+        run: podman rmi --force --all
+        if: always()

--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ This is done with the zenfs utility, using the mkfs command:
 ./plugin/zenfs/util/zenfs mkfs --zbd=<zoned block device> --aux_path=<path to store LOG and LOCK files>
 ```
 
+## Test
+
+ZenFS uses RocksDB gtest infrastructure for testing. See
+[gtest](https://google.github.io/googletest/) documentation for details on the
+test framework and how to add tests. ZenFS tests require a zoned block device to operate. Pass the name of the device in the `DEVICE` environment variable. You do not need to create a ZenFS filesystem on the device, the test will do that. *Note that all data on the device will be lost*.
+
+To run all RocksDB tests:
+
+```shell
+make DEBUG_LEVEL=1 ROCKSDB_PLUGINS=zenfs DEVICE=nullb0 check
+```
+See RocksDB `Makefile` for details on the `check` target.
+
+To build a single test:
+```shell
+make DEBUG_LEVEL=1 ROCKSDB_PLUGINS=zenfs fs_zenfs_test
+```
+
+To run the test, set `DEVICE` environment variable and execute the test:
+```shell
+DEVICE=null0 ./fs_zenfs_test
+```
 ## ZenFS on-disk file formats
 
 ZenFS Version 1.0.0 and earlier uses version 1 of the on-disk format.

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -6,13 +6,13 @@
 
 #pragma once
 
+#include <filesystem>
 #include <memory>
 
 #include "io_zenfs.h"
 #include "metrics.h"
 #include "rocksdb/env.h"
 #include "rocksdb/file_system.h"
-#include "rocksdb/status.h"
 #include "snapshot.h"
 #include "version.h"
 #include "zbd_zenfs.h"
@@ -257,12 +257,14 @@ class ZenFS : public FileSystemWrapper {
                             IODebugContext* dbg, bool reopen);
 
  public:
-  explicit ZenFS(ZonedBlockDevice* zbd, std::shared_ptr<FileSystem> aux_fs,
+  explicit ZenFS(std::unique_ptr<ZonedBlockDevice> zbd,
+                 std::shared_ptr<FileSystem> aux_fs,
                  std::shared_ptr<Logger> logger);
   virtual ~ZenFS();
 
   Status Mount(bool readonly);
-  Status MkFS(std::string aux_fs_path, uint32_t finish_threshold);
+  Status MkFS(std::filesystem::path const& aux_fs_path,
+              uint32_t finish_threshold);
   std::map<std::string, Env::WriteLifeTimeHint> GetWriteLifeTimeHints();
 
   const char* Name() const override {

--- a/fs/test/fs_zenfs_test.cc
+++ b/fs/test/fs_zenfs_test.cc
@@ -1,0 +1,83 @@
+
+
+#include "../fs_zenfs.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <memory>
+
+#include "../util.h"
+#include "rocksdb/convenience.h"
+#include "rocksdb/env.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+class FsZenFSTest : public testing::Test {
+ private:
+  std::filesystem::path aux_path;
+
+  void uniqueue_path(std::filesystem::path& out_path) {
+    char* name = std::tmpnam(nullptr);
+    ASSERT_TRUE(name != nullptr);
+
+    out_path = std::filesystem::path(name);
+  }
+
+ public:
+  std::shared_ptr<FileSystem> fs_;
+
+  FsZenFSTest() {}
+
+ protected:
+  void CreateFilesystem(std::string const& device) {
+    Status status;
+    namespace fs = std::filesystem;
+    using fs::path;
+
+    uniqueue_path(aux_path);
+    status = zenfs_mkfs(device, aux_path, 0, true);
+    ASSERT_TRUE(status.ok())
+        << "Failed to create ZenFS filesystem on device : " << device
+        << " with aux path: " << aux_path << " error: " << status.ToString();
+  }
+
+  void SetUp() override {
+    Status status;
+    std::string fs_uri;
+    char* env_device;
+    ConfigOptions config_options;
+
+    env_device = std::getenv("DEVICE");
+    ASSERT_TRUE(env_device != nullptr) << "DEVICE environment variable not set";
+
+    CreateFilesystem(env_device);
+
+    config_options.ignore_unsupported_options = false;
+    fs_uri = "zenfs://dev:" + std::string(env_device);
+    status = FileSystem::CreateFromString(config_options, fs_uri, &fs_);
+    ASSERT_TRUE(status.ok()) << "Failed to create ZenFS instance";
+  }
+
+  void TearDown() override { std::filesystem::remove_all(aux_path); }
+};
+
+TEST_F(FsZenFSTest, Example) {
+  IOStatus status;
+
+  ASSERT_TRUE(1);
+
+  IOOptions options;
+  status = fs_->CreateDir("test", options, nullptr);
+  ASSERT_TRUE(status.ok()) << "Failed to create directory 'test'";
+
+  status = fs_->CreateDir("test", options, nullptr);
+  ASSERT_TRUE(!status.ok()) << "Directory 'test' could be created twice";
+};
+}  // namespace ROCKSDB_NAMESPACE
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/fs/util.cc
+++ b/fs/util.cc
@@ -1,0 +1,153 @@
+
+#include "util.h"
+
+#include <dirent.h>
+#include <libzbd/zbd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <system_error>
+
+#include "fs_zenfs.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+std::unique_ptr<ZonedBlockDevice> zbd_open(std::string const &zbd_path,
+                                           bool readonly, bool exclusive) {
+  std::unique_ptr<ZonedBlockDevice> zbd{
+      new ZonedBlockDevice(zbd_path, nullptr)};
+  IOStatus open_status = zbd->Open(readonly, exclusive);
+
+  if (!open_status.ok()) {
+    fprintf(stderr, "Failed to open zoned block device: %s, error: %s\n",
+            zbd_path.c_str(), open_status.ToString().c_str());
+    zbd.reset();
+  }
+
+  return zbd;
+}
+
+// Here we pass 'zbd' by non-const reference to be able to pass its ownership
+// to 'zenFS'
+Status zenfs_mount(std::unique_ptr<ZonedBlockDevice> &zbd,
+                   std::unique_ptr<ZenFS> *zenFS, bool readonly) {
+  Status s;
+
+  std::unique_ptr<ZenFS> localZenFS{
+      new ZenFS(zbd.release(), FileSystem::Default(), nullptr)};
+  s = localZenFS->Mount(readonly);
+  if (!s.ok()) {
+    localZenFS.reset();
+  }
+  *zenFS = std::move(localZenFS);
+
+  return s;
+}
+
+static int is_dir(const char *path) {
+  struct stat st;
+  if (stat(path, &st) != 0) {
+    fprintf(stderr, "Failed to stat %s\n", path);
+    return 1;
+  }
+  return S_ISDIR(st.st_mode);
+}
+
+// Create or check pre-existing aux directory and fail if it is
+// inaccessible by current user and if it has previous data
+static int create_aux_dir(const char *path) {
+  struct dirent *dent;
+  size_t nfiles = 0;
+  int ret = 0;
+
+  errno = 0;
+  ret = mkdir(path, 0750);
+  if (ret < 0 && EEXIST != errno) {
+    fprintf(stderr, "Failed to create aux directory %s: %s\n", path,
+            strerror(errno));
+    return 1;
+  }
+  // The aux_path is now available, check if it is a directory infact
+  // and is empty and the user has access permission
+
+  if (!is_dir(path)) {
+    fprintf(stderr, "Aux path %s is not a directory\n", path);
+    return 1;
+  }
+
+  errno = 0;
+
+  auto closedirDeleter = [](DIR *d) {
+    if (d != nullptr) closedir(d);
+  };
+  std::unique_ptr<DIR, decltype(closedirDeleter)> aux_dir{
+      opendir(path), std::move(closedirDeleter)};
+  if (errno) {
+    fprintf(stderr, "Failed to open aux directory %s: %s\n", path,
+            strerror(errno));
+    return 1;
+  }
+
+  // Consider the directory as non-empty if any files/dir other
+  // than . and .. are found.
+  while ((dent = readdir(aux_dir.get())) != NULL && nfiles <= 2) ++nfiles;
+  if (nfiles > 2) {
+    fprintf(stderr, "Aux directory %s is not empty.\n", path);
+    return 1;
+  }
+
+  if (access(path, R_OK | W_OK | X_OK) < 0) {
+    fprintf(stderr,
+            "User does not have access permissions on "
+            "aux directory %s\n",
+            path);
+    return 1;
+  }
+
+  return 0;
+}
+
+int zenfs_mkfs(std::string const &zbd_path, std::string const &aux_path,
+               int finish_threshold, bool force) {
+  Status s;
+
+  if (create_aux_dir(aux_path.c_str())) return 1;
+
+  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(zbd_path, false, true);
+  if (!zbd) return 1;
+
+  std::unique_ptr<ZenFS> zenFS;
+  s = zenfs_mount(zbd, &zenFS, false);
+  if ((s.ok() || !s.IsNotFound()) && !force) {
+    fprintf(
+        stderr,
+        "Existing filesystem found, use --force if you want to replace it.\n");
+    return 1;
+  }
+
+  zenFS.reset();
+
+  zbd = zbd_open(zbd_path, false, true);
+  ZonedBlockDevice *zbdRaw = zbd.get();
+  zenFS.reset(new ZenFS(zbd.release(), FileSystem::Default(), nullptr));
+
+  std::string aux_path_patched = aux_path;
+  if (aux_path_patched.back() != '/') aux_path_patched.append("/");
+
+  s = zenFS->MkFS(aux_path_patched, finish_threshold);
+  if (!s.ok()) {
+    fprintf(stderr, "Failed to create file system, error: %s\n",
+            s.ToString().c_str());
+    return 1;
+  }
+
+  fprintf(stdout, "ZenFS file system created. Free space: %lu MB\n",
+          zbdRaw->GetFreeSpace() / (1024 * 1024));
+
+  return 0;
+}
+}  // namespace ROCKSDB_NAMESPACE

--- a/fs/util.h
+++ b/fs/util.h
@@ -8,12 +8,14 @@
 
 namespace ROCKSDB_NAMESPACE {
 
-std::unique_ptr<ZonedBlockDevice> zbd_open(std::string const& zbd_path,
-                                           bool readonly, bool exclusive);
+IOStatus zenfs_zbd_open(std::filesystem::path const &path, bool readonly,
+                        bool exclusive,
+                        std::unique_ptr<ZonedBlockDevice> &out_zbd);
 
-Status zenfs_mount(std::unique_ptr<ZonedBlockDevice>& zbd,
-                   std::unique_ptr<ZenFS>* zenFS, bool readonly);
+Status zenfs_mount(std::unique_ptr<ZonedBlockDevice> &zbd, bool readonly,
+                   std::unique_ptr<ZenFS> &out_zen_fs);
 
-int zenfs_mkfs(std::string const& zbd_path, std::string const& aux_path,
-               int finish_threshold, bool force);
+Status zenfs_mkfs(std::filesystem::path const &zbd_path,
+                  std::filesystem::path const &aux_path,
+                  uint32_t finish_threshold, bool force);
 }  // namespace ROCKSDB_NAMESPACE

--- a/fs/util.h
+++ b/fs/util.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+
+#include "fs_zenfs.h"
+#include "rocksdb/status.h"
+
+namespace ROCKSDB_NAMESPACE {
+
+std::unique_ptr<ZonedBlockDevice> zbd_open(std::string const& zbd_path,
+                                           bool readonly, bool exclusive);
+
+Status zenfs_mount(std::unique_ptr<ZonedBlockDevice>& zbd,
+                   std::unique_ptr<ZenFS>* zenFS, bool readonly);
+
+int zenfs_mkfs(std::string const& zbd_path, std::string const& aux_path,
+               int finish_threshold, bool force);
+}  // namespace ROCKSDB_NAMESPACE

--- a/test-mk/test.mk
+++ b/test-mk/test.mk
@@ -1,0 +1,3 @@
+
+fs_zenfs_test: $(OBJ_DIR)/plugin/zenfs/fs/test/fs_zenfs_test.o $(TEST_LIBRARY) $(LIBRARY)
+	$(AM_LINK)

--- a/util/Makefile
+++ b/util/Makefile
@@ -6,7 +6,7 @@ CC ?= gcc
 CXX ?= g++
 OBJCOPY ?= objcopy
 
-CXXFLAGS := $(shell pkg-config --cflags rocksdb)
+CXXFLAGS := $(shell pkg-config --cflags rocksdb) -std=c++17
 ifneq ($(.SHELLSTATUS),0)
 $(error pkg-config failed)
 endif

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -30,7 +30,6 @@
 #endif
 
 using GFLAGS_NAMESPACE::ParseCommandLineFlags;
-using GFLAGS_NAMESPACE::RegisterFlagValidator;
 using GFLAGS_NAMESPACE::SetUsageMessage;
 
 DEFINE_string(zbd, "", "Path to a zoned block device.");

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -20,9 +20,11 @@
 
 #ifdef WITH_TERARKDB
 #include <fs/fs_zenfs.h>
+#include <fs/util.h>
 #include <fs/version.h>
 #else
 #include <rocksdb/plugin/zenfs/fs/fs_zenfs.h>
+#include <rocksdb/plugin/zenfs/fs/util.h>
 #include <rocksdb/plugin/zenfs/fs/version.h>
 #endif
 
@@ -77,100 +79,6 @@ bool zenfs_format_path(std::string &path, bool directory) {
   return true;
 }
 
-std::unique_ptr<ZonedBlockDevice> zbd_open(bool readonly, bool exclusive) {
-  std::unique_ptr<ZonedBlockDevice> zbd{
-      new ZonedBlockDevice(FLAGS_zbd, nullptr)};
-  IOStatus open_status = zbd->Open(readonly, exclusive);
-
-  if (!open_status.ok()) {
-    fprintf(stderr, "Failed to open zoned block device: %s, error: %s\n",
-            FLAGS_zbd.c_str(), open_status.ToString().c_str());
-    zbd.reset();
-  }
-
-  return zbd;
-}
-
-// Here we pass 'zbd' by non-const reference to be able to pass its ownership
-// to 'zenFS'
-Status zenfs_mount(std::unique_ptr<ZonedBlockDevice> &zbd,
-                   std::unique_ptr<ZenFS> *zenFS, bool readonly) {
-  Status s;
-
-  std::unique_ptr<ZenFS> localZenFS{
-      new ZenFS(zbd.release(), FileSystem::Default(), nullptr)};
-  s = localZenFS->Mount(readonly);
-  if (!s.ok()) {
-    localZenFS.reset();
-  }
-  *zenFS = std::move(localZenFS);
-
-  return s;
-}
-
-int is_dir(const char *path) {
-  struct stat st;
-  if (stat(path, &st) != 0) {
-    fprintf(stderr, "Failed to stat %s\n", path);
-    return 1;
-  }
-  return S_ISDIR(st.st_mode);
-}
-
-// Create or check pre-existing aux directory and fail if it is
-// inaccessible by current user and if it has previous data
-int create_aux_dir(const char *path) {
-  struct dirent *dent;
-  size_t nfiles = 0;
-  int ret = 0;
-
-  errno = 0;
-  ret = mkdir(path, 0750);
-  if (ret < 0 && EEXIST != errno) {
-    fprintf(stderr, "Failed to create aux directory %s: %s\n", path,
-            strerror(errno));
-    return 1;
-  }
-  // The aux_path is now available, check if it is a directory infact
-  // and is empty and the user has access permission
-
-  if (!is_dir(path)) {
-    fprintf(stderr, "Aux path %s is not a directory\n", path);
-    return 1;
-  }
-
-  errno = 0;
-
-  auto closedirDeleter = [](DIR *d) {
-    if (d != nullptr) closedir(d);
-  };
-  std::unique_ptr<DIR, decltype(closedirDeleter)> aux_dir{
-      opendir(path), std::move(closedirDeleter)};
-  if (errno) {
-    fprintf(stderr, "Failed to open aux directory %s: %s\n", path,
-            strerror(errno));
-    return 1;
-  }
-
-  // Consider the directory as non-empty if any files/dir other
-  // than . and .. are found.
-  while ((dent = readdir(aux_dir.get())) != NULL && nfiles <= 2) ++nfiles;
-  if (nfiles > 2) {
-    fprintf(stderr, "Aux directory %s is not empty.\n", path);
-    return 1;
-  }
-
-  if (access(path, R_OK | W_OK | X_OK) < 0) {
-    fprintf(stderr,
-            "User does not have access permissions on "
-            "aux directory %s\n",
-            path);
-    return 1;
-  }
-
-  return 0;
-}
-
 int zenfs_tool_mkfs() {
   Status s;
 
@@ -179,39 +87,9 @@ int zenfs_tool_mkfs() {
     return 1;
   }
 
-  if (create_aux_dir(FLAGS_aux_path.c_str())) return 1;
-
-  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(false, true);
-  if (!zbd) return 1;
-
-  std::unique_ptr<ZenFS> zenFS;
-  s = zenfs_mount(zbd, &zenFS, false);
-  if ((s.ok() || !s.IsNotFound()) && !FLAGS_force) {
-    fprintf(
-        stderr,
-        "Existing filesystem found, use --force if you want to replace it.\n");
-    return 1;
-  }
-
-  zenFS.reset();
-
-  zbd = zbd_open(false, true);
-  ZonedBlockDevice *zbdRaw = zbd.get();
-  zenFS.reset(new ZenFS(zbd.release(), FileSystem::Default(), nullptr));
-
-  if (FLAGS_aux_path.back() != '/') FLAGS_aux_path.append("/");
-
-  s = zenFS->MkFS(FLAGS_aux_path, FLAGS_finish_threshold);
-  if (!s.ok()) {
-    fprintf(stderr, "Failed to create file system, error: %s\n",
-            s.ToString().c_str());
-    return 1;
-  }
-
-  fprintf(stdout, "ZenFS file system created. Free space: %lu MB\n",
-          zbdRaw->GetFreeSpace() / (1024 * 1024));
-
-  return 0;
+  return zenfs_mkfs(std::filesystem::path(FLAGS_zbd),
+                    std::filesystem::path(FLAGS_aux_path),
+                    FLAGS_finish_threshold, FLAGS_force);
 }
 
 void list_children(const std::unique_ptr<ZenFS> &zenFS,
@@ -255,7 +133,7 @@ void list_children(const std::unique_ptr<ZenFS> &zenFS,
 
 int zenfs_tool_list() {
   Status s;
-  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(true, false);
+  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(FLAGS_zbd, true, false);
   if (!zbd) return 1;
 
   std::unique_ptr<ZenFS> zenFS;
@@ -277,7 +155,7 @@ int zenfs_tool_list() {
 
 int zenfs_tool_df() {
   Status s;
-  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(true, false);
+  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(FLAGS_zbd, true, false);
   if (!zbd) return 1;
   ZonedBlockDevice *zbdRaw = zbd.get();
 
@@ -497,7 +375,7 @@ int zenfs_tool_backup() {
   IOStatus io_status;
   IOOptions opts;
   IODebugContext dbg;
-  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(true, true);
+  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(FLAGS_zbd, true, true);
 
   if (!zenfs_format_path(FLAGS_backup_path, false)) {
     fprintf(stderr, "Error: invalid backup path \n");
@@ -509,7 +387,7 @@ int zenfs_tool_backup() {
       fprintf(stderr,
               "WARNING: attempting to back up a zoned block device in use! "
               "Expect data loss and corruption.\n");
-      zbd = zbd_open(true, false);
+      zbd = zbd_open(FLAGS_zbd, true, false);
     }
   }
 
@@ -711,7 +589,7 @@ int zenfs_tool_restore() {
 
   ReadWriteLifeTimeHints();
 
-  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(false, true);
+  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(FLAGS_zbd, false, true);
   if (!zbd) return 1;
 
   std::unique_ptr<ZenFS> zenFS;
@@ -744,7 +622,7 @@ int zenfs_tool_restore() {
 
 int zenfs_tool_dump() {
   Status s;
-  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(true, false);
+  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(FLAGS_zbd, true, false);
   if (!zbd) return 1;
   ZonedBlockDevice *zbdRaw = zbd.get();
 
@@ -768,7 +646,7 @@ int zenfs_tool_dump() {
 
 int zenfs_tool_fsinfo() {
   Status s;
-  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(true, false);
+  std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(FLAGS_zbd, true, false);
   if (!zbd) return 1;
 
   std::unique_ptr<ZenFS> zenFS;

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,5 +1,18 @@
-zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
-zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/version.h fs/metrics.h fs/snapshot.h
+zenfs_SOURCES = \
+	fs/fs_zenfs.cc \
+	fs/zbd_zenfs.cc \
+	fs/io_zenfs.cc \
+	fs/util.cc
+
+zenfs_HEADERS = \
+	fs/fs_zenfs.h \
+	fs/zbd_zenfs.h \
+	fs/io_zenfs.h \
+	fs/version.h \
+	fs/metrics.h \
+	fs/snapshot.h \
+	fs/util.h
+
 zenfs_LDFLAGS = -u zenfs_filesystem_reg
 
 ZENFS_ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -14,6 +14,7 @@ zenfs_HEADERS = \
 	fs/util.h
 
 zenfs_LDFLAGS = -u zenfs_filesystem_reg
+zenfs_TEST_MAIN_SOURCES = fs/test/fs_zenfs_test.cc
 
 ZENFS_ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 


### PR DESCRIPTION
This patch adds a simple integration test based on RocksDB gtest infrastructure.
To be functional, the patch requires changes in rocksdb. The patch for rocksdb
is currenlty on top of the 6.29.3 branch and can be found [here](https://github.com/metaspace/rocksdb/tree/6.29.3-plugin-tests).