### PR TITLE
fs: format all input paths into ZenFs lexically

### DIFF
--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <filesystem>
 #include <memory>
 
 #include "io_zenfs.h"
@@ -154,6 +155,7 @@ class ZenFS : public FileSystemWrapper {
 
   void LogFiles();
   void ClearFiles();
+  std::string FormatPathLexically(std::filesystem::path filepath);
   IOStatus WriteSnapshotLocked(ZenMetaLog* meta_log);
   IOStatus WriteEndRecord(ZenMetaLog* meta_log);
   IOStatus RollMetaZoneLocked();

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -671,6 +671,11 @@ int zenfs_tool_restore() {
   Status status;
   IOStatus io_status;
 
+  if (FLAGS_path.empty()) {
+    fprintf(stderr, "Error: Specify --path to be restored.\n");
+    return 1;
+  }
+
   AddDirSeparatorAtEnd(FLAGS_restore_path);
   ReadWriteLifeTimeHints();
 

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -677,6 +677,7 @@ int zenfs_tool_restore() {
   }
 
   AddDirSeparatorAtEnd(FLAGS_restore_path);
+  AddDirSeparatorAtEnd(FLAGS_path);
   ReadWriteLifeTimeHints();
 
   std::unique_ptr<ZonedBlockDevice> zbd = zbd_open(false, true);
@@ -690,9 +691,6 @@ int zenfs_tool_restore() {
     return 1;
   }
 
-  std::string path = FLAGS_path;
-  if (path.back() != '/') path += "/";
-
   io_status = zenfs_create_directories(zenFS.get(), FLAGS_restore_path);
   if (!io_status.ok()) {
     fprintf(stderr, "Create directory failed, error: %s\n",
@@ -700,7 +698,7 @@ int zenfs_tool_restore() {
     return 1;
   }
 
-  io_status = zenfs_tool_copy_dir(FileSystem::Default().get(), path,
+  io_status = zenfs_tool_copy_dir(FileSystem::Default().get(), FLAGS_path,
                                   zenFS.get(), FLAGS_restore_path);
   if (!io_status.ok()) {
     fprintf(stderr, "Copy failed, error: %s\n", io_status.ToString().c_str());


### PR DESCRIPTION
It formats input paths lexically, to handle scenarios like
relative paths, superfluous slashes.

Signed-off-by: Aravind Ramesh <aravind.ramesh@wdc.com>