### PR TITLE
fs: Fix extent blocks compute error for sparse recovery

### DIFF
--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -645,7 +645,10 @@ IOStatus ZoneFile::RecoverSparseExtents(uint64_t start, uint64_t end,
     extents_.push_back(new ZoneExtent(next_extent_start + SPARSE_HEADER_SIZE,
                                       extent_length, zone));
 
-    uint64_t extent_blocks = 1 + extent_length / block_sz;
+    uint64_t extent_blocks = (extent_length + SPARSE_HEADER_SIZE) / block_sz;
+    if ((extent_length + SPARSE_HEADER_SIZE) % block_sz) {
+      extent_blocks++;
+    }
     next_extent_start += extent_blocks * block_sz;
   }
 


### PR DESCRIPTION
Ex: extent_length is 4094, sparse head+data+pad, it needs 2 blocks, not 1

Signed-off-by: hml1006 <hml1006@qq.com>
Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>
(fixed up commit message)