### PR TITLE
Garbage collection

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -106,6 +106,8 @@ void Superblock::GetReport(std::string* reportString) {
   reportString->append(std::to_string(nr_zones_));
   reportString->append("\nFinish Threshold [%]:\t\t");
   reportString->append(std::to_string(finish_treshold_));
+  reportString->append("\nGarbage Collection Enabled:\t");
+  reportString->append(std::to_string(!!(flags_ & FLAGS_ENABLE_GC)));
   reportString->append("\nAuxiliary FS Path:\t\t");
   reportString->append(aux_fs_path_);
   reportString->append("\nZenFS Version:\t\t\t");
@@ -1428,7 +1430,8 @@ Status ZenFS::Mount(bool readonly) {
   return Status::OK();
 }
 
-Status ZenFS::MkFS(std::string aux_fs_p, uint32_t finish_threshold) {
+Status ZenFS::MkFS(std::string aux_fs_p, uint32_t finish_threshold,
+                   bool enable_gc) {
   std::vector<Zone*> metazones = zbd_->GetMetaZones();
   std::unique_ptr<ZenMetaLog> log;
   Zone* meta_zone = nullptr;
@@ -1472,7 +1475,7 @@ Status ZenFS::MkFS(std::string aux_fs_p, uint32_t finish_threshold) {
 
   log.reset(new ZenMetaLog(zbd_, meta_zone));
 
-  Superblock super(zbd_, aux_fs_path, finish_threshold);
+  Superblock super(zbd_, aux_fs_path, finish_threshold, enable_gc);
   std::string super_string;
   super.EncodeTo(&super_string);
 

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -47,6 +47,7 @@ DEFINE_string(restore_path, "", "Path to restore files");
 DEFINE_string(backup_path, "", "Path to backup files");
 DEFINE_string(src_file, "", "Source file path");
 DEFINE_string(dest_file, "", "Destination file path");
+DEFINE_bool(enable_gc, false, "Enable garbage collection");
 
 namespace ROCKSDB_NAMESPACE {
 
@@ -181,7 +182,7 @@ int zenfs_tool_mkfs() {
 
   AddDirSeparatorAtEnd(FLAGS_aux_path);
 
-  s = zenFS->MkFS(FLAGS_aux_path, FLAGS_finish_threshold);
+  s = zenFS->MkFS(FLAGS_aux_path, FLAGS_finish_threshold, FLAGS_enable_gc);
   if (!s.ok()) {
     fprintf(stderr, "Failed to create file system, error: %s\n",
             s.ToString().c_str());


### PR DESCRIPTION
Add an option to enable garbage collection in zenfs.

The garbage collection, if enabled, kicks in under 20% capacity left and cleans out zones with 1% valid data in them to start off with, increasing to 40% at 99% capacity.

This scheme reduces space amplification down to as little as 5% (from ~10-15%) in my testing.