### PR TITLE
fs, util: Use boost libraries for C++ std < C++17

### DIFF
--- a/fs/filesystem_utility.h
+++ b/fs/filesystem_utility.h
@@ -1,0 +1,121 @@
+//  SPDX-License-Identifier: Apache License 2.0 OR GPL-2.0
+//
+//  SPDX-FileCopyrightText: 2022, Western Digital Corporation or its affiliates.
+//  Written by Kuankuan Guo <guokuankuan@bytedance.com>
+//
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// Utility filesystem path implementation
+namespace filesystem_utility {
+class path {
+ public:
+  path(const std::string& src_path) : src_path_(src_path) {
+    lexically_normal();
+  }
+  path() { path(""); }
+  std::string string() const { return normalized_path_; }
+  operator std::string() const { return string(); }
+
+  // Normalize the input path, keep the root slash and end
+  // terminator, example:
+  //
+  // `//a/b/c    ->   /a/b/c`
+  // `a/b/../c/  ->   a/c/`
+  // `a/b/../c   ->   a/c`
+  path lexically_normal() {
+    if (!normalized_path_.empty()) {
+      return *this;
+    }
+
+    if (src_path_.empty()) {
+      normalized_path_ = "";
+      return *this;
+    }
+
+    if (src_path_.compare("/") == 0) {
+      normalized_path_ = src_path_;
+      return *this;
+    }
+
+    std::stringstream rst;
+    std::vector<std::string> segs;
+
+    std::istringstream iss(src_path_);
+    std::string item;
+    while (std::getline(iss, item, '/')) {
+      if (item == ".." && segs.size() > 0) {
+        segs.pop_back();
+        continue;
+      }
+
+      if (item == ".") {
+        continue;
+      }
+      if (!item.empty()) {
+        segs.emplace_back(item);
+      }
+    }
+
+    // We don't expect strings with the "../" prefix
+    assert(segs[0] != "..");
+
+    // We have a filename only if we don't have a terminator
+    bool has_terminator = *(--src_path_.end()) == '/';
+    if (!has_terminator) {
+      filename_ = *(--segs.end());
+    }
+
+    // Keep the root slash
+    if (src_path_[0] == '/') {
+      rst << "/";
+    }
+
+    for (size_t i = 0; i < segs.size(); ++i) {
+      rst << segs[i];
+      // The parent path represent higher-level directory, note that if
+      // the source path is already a directory, the result reminds the
+      // same.
+      //
+      // `/a/b/c   ->  /a/b/ `
+      // `/a/b/c/` ->  /a/b/c/ `
+      if (!has_terminator && i == segs.size() - 2) {
+        parent_path_ = rst.str() + "/";
+      }
+      if (!has_terminator && i == segs.size() - 1) {
+        break;
+      }
+      rst << "/";
+    }
+
+    normalized_path_ = rst.str();
+    // If current source path is a directory, the parent path reminds the
+    // same (@see std::filesystem::path::parent_path())
+    if (has_terminator) {
+      parent_path_ = normalized_path_;
+    }
+    return *this;
+  }
+
+  std::string parent_path() const { return parent_path_; }
+
+  path filename() { return path(filename_); }
+
+  bool has_filename() { return !filename_.empty(); }
+
+  path operator/(const path& other) const {
+    return path(normalized_path_ + other.string());
+  }
+
+ private:
+  std::string src_path_;
+  std::string normalized_path_;
+  std::string parent_path_;
+  // @see std::filesystem::path::filename()
+  std::string filename_;
+};
+}  // namespace filesystem_utility

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -271,8 +271,8 @@ IOStatus ZenFS::Repair() {
   return IOStatus::OK();
 }
 
-std::string ZenFS::FormatPathLexically(std::filesystem::path filepath) {
-  std::filesystem::path ret = "/" / filepath.lexically_normal();
+std::string ZenFS::FormatPathLexically(fs::path filepath) {
+  fs::path ret = fs::path("/") / filepath.lexically_normal();
   return ret.string();
 }
 
@@ -638,11 +638,10 @@ IOStatus ZenFS::ReopenWritableFile(const std::string& filename,
 void ZenFS::GetZenFSChildrenNoLock(const std::string& dir,
                                    bool include_grandchildren,
                                    std::vector<std::string>* result) {
-  auto path_as_string_with_separator_at_end =
-      [](std::filesystem::path const& path) {
-        auto with_sep = path / "";
-        return with_sep.lexically_normal().string();
-      };
+  auto path_as_string_with_separator_at_end = [](fs::path const& path) {
+    fs::path with_sep = path / fs::path("");
+    return with_sep.lexically_normal().string();
+  };
 
   auto string_starts_with = [](std::string const& string,
                                std::string const& needle) {
@@ -650,7 +649,7 @@ void ZenFS::GetZenFSChildrenNoLock(const std::string& dir,
   };
 
   std::string dir_with_terminating_seperator =
-      path_as_string_with_separator_at_end(std::filesystem::path(dir));
+      path_as_string_with_separator_at_end(fs::path(dir));
 
   auto relative_child_path =
       [&dir_with_terminating_seperator](std::string const& full_path) {
@@ -658,7 +657,7 @@ void ZenFS::GetZenFSChildrenNoLock(const std::string& dir,
       };
 
   for (auto const& it : files_) {
-    std::filesystem::path file_path(it.first);
+    fs::path file_path(it.first);
     assert(file_path.has_filename());
 
     std::string file_dir =
@@ -667,7 +666,7 @@ void ZenFS::GetZenFSChildrenNoLock(const std::string& dir,
     if (string_starts_with(file_dir, dir_with_terminating_seperator)) {
       if (include_grandchildren ||
           file_dir.length() == dir_with_terminating_seperator.length()) {
-        result->push_back(relative_child_path(file_path));
+        result->push_back(relative_child_path(file_path.string()));
       }
     }
   }
@@ -728,8 +727,7 @@ IOStatus ZenFS::DeleteDirRecursiveNoLock(const std::string& dir,
   }
 
   for (const auto& child : children) {
-    std::string file_to_delete =
-        (std::filesystem::path(d) / std::filesystem::path(child)).string();
+    std::string file_to_delete = (fs::path(d) / fs::path(child)).string();
     bool is_dir;
 
     s = IsDirectoryNoLock(file_to_delete, options, &is_dir, dbg);
@@ -874,11 +872,8 @@ IOStatus ZenFS::RenameChildNoLock(std::string const& source_dir,
                                   std::string const& child,
                                   const IOOptions& options,
                                   IODebugContext* dbg) {
-  std::string source_child =
-      (std::filesystem::path(source_dir) / std::filesystem::path(child))
-          .string();
-  std::string dest_child =
-      (std::filesystem::path(dest_dir) / std::filesystem::path(child)).string();
+  std::string source_child = (fs::path(source_dir) / fs::path(child)).string();
+  std::string dest_child = (fs::path(dest_dir) / fs::path(child)).string();
   return RenameFileNoLock(source_child, dest_child, options, dbg);
 }
 

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -6,7 +6,14 @@
 
 #pragma once
 
+#if __cplusplus < 201703L
+#include "filesystem_utility.h"
+namespace fs = filesystem_utility;
+#else
 #include <filesystem>
+namespace fs = std::filesystem;
+#endif
+
 #include <memory>
 
 #include "io_zenfs.h"
@@ -155,7 +162,7 @@ class ZenFS : public FileSystemWrapper {
 
   void LogFiles();
   void ClearFiles();
-  std::string FormatPathLexically(std::filesystem::path filepath);
+  std::string FormatPathLexically(fs::path filepath);
   IOStatus WriteSnapshotLocked(ZenMetaLog* meta_log);
   IOStatus WriteEndRecord(ZenMetaLog* meta_log);
   IOStatus RollMetaZoneLocked();

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -680,7 +680,7 @@ int zenfs_tool_restore() {
   }
 
   AddDirSeparatorAtEnd(FLAGS_restore_path);
-  std::filesystem::path fpath(FLAGS_path);
+  fs::path fpath(FLAGS_path);
   FLAGS_path = fpath.lexically_normal().string();
   FileSystem *f_fs = FileSystem::Default().get();
   status = f_fs->IsDirectory(FLAGS_path, opts, &is_dir, &dbg);

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,5 +1,5 @@
 zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
-zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/version.h fs/metrics.h fs/snapshot.h
+zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/version.h fs/metrics.h fs/snapshot.h fs/filesystem_utility.h
 zenfs_LDFLAGS = -u zenfs_filesystem_reg
 
 ZENFS_ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
C++17 was mandatory, since we were using std::filesystem(::path) and
RocksDB also moved on to C++17.

With this commit boost::filesystem replaces std::filesystem if
the C++ std < C++17 when compiling.

Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>