### PR TITLE
zbd: add garbage collection stats interface

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1717,8 +1717,10 @@ IOStatus ZenFS::MigrateFileExtents(
       zfile->MigrateData(ext->start_ - ZoneFile::SPARSE_HEADER_SIZE,
                          ext->length_ + ZoneFile::SPARSE_HEADER_SIZE,
                          target_zone);
+      zbd_->AddGCBytesWritten(ext->length_ + ZoneFile::SPARSE_HEADER_SIZE);
     } else {
       zfile->MigrateData(ext->start_, ext->length_, target_zone);
+      zbd_->AddGCBytesWritten(ext->length_);
     }
 
     // If the file doesn't exist, skip

--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -159,6 +159,7 @@ IOStatus Zone::Append(char *data, uint32_t size) {
     wp_ += ret;
     capacity_ -= ret;
     left -= ret;
+    zbd_->AddBytesWritten(ret);
   }
 
   return IOStatus::OK();

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -90,6 +90,8 @@ class ZonedBlockDevice {
   time_t start_time_;
   std::shared_ptr<Logger> logger_;
   uint32_t finish_threshold_ = 0;
+  std::atomic<uint64_t> bytes_written_{0};
+  std::atomic<uint64_t> gc_bytes_written_{0};
 
   std::atomic<long> active_io_zones_;
   std::atomic<long> open_io_zones_;
@@ -167,6 +169,13 @@ class ZonedBlockDevice {
 
   IOStatus TakeMigrateZone(Zone **out_zone, Env::WriteLifeTimeHint lifetime,
                            uint32_t min_capacity);
+
+  void AddBytesWritten(uint64_t written) { bytes_written_ += written; };
+  void AddGCBytesWritten(uint64_t written) { gc_bytes_written_ += written; };
+  uint64_t GetUserBytesWritten() {
+    return bytes_written_.load() - gc_bytes_written_.load();
+  };
+  uint64_t GetTotalBytesWritten() { return bytes_written_.load(); };
 
  private:
   std::string ErrorToString(int err);


### PR DESCRIPTION
Keep track of how many total bytes that are written and
how many bytes that are moved during garbage collection
to allow for write amp statistics to be calculated.

Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>