### PR TITLE
fs: Add metrics prometheus exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ The convenience script can be used to run all crashtest sets defined in `tests/c
 cd tests; ./zenfs_base_crashtest.sh <zoned block device name>
 ```
 
+## Prometheus Metrics Exporter
+
+To export performance metrics to Prometheus, do the following:
+
+Set environment variable ZENFS_EXPORT_PROMETHEUS=y when building to enable
+prometheus export of metrics. Exporter will listen on 127.0.0.1:8080.
+
+**Requires prometheus-cpp-pull == 1.1.0**
+
 # ZenFS Internals
 
 ## Architecture overview

--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -19,6 +19,9 @@
 #include <utility>
 #include <vector>
 
+#ifdef ZENFS_EXPORT_PROMETHEUS
+#include "metrics_prometheus.h"
+#endif
 #include "rocksdb/utilities/object_registry.h"
 #include "snapshot.h"
 #include "util/coding.h"
@@ -1779,7 +1782,12 @@ FactoryFunc<FileSystem> zenfs_filesystem_reg =
           devID.replace(0, strlen("zenfs://"), "");
           if (devID.rfind("dev:") == 0) {
             devID.replace(0, strlen("dev:"), "");
+#ifdef ZENFS_EXPORT_PROMETHEUS
+            s = NewZenFS(&fs, devID,
+                         std::make_shared<ZenFSPrometheusMetrics>());
+#else
             s = NewZenFS(&fs, devID);
+#endif
             if (!s.ok()) {
               *errmsg = s.ToString();
             }
@@ -1794,7 +1802,13 @@ FactoryFunc<FileSystem> zenfs_filesystem_reg =
               if (zenFileSystems.find(devID) == zenFileSystems.end()) {
                 *errmsg = "UUID not found";
               } else {
+
+#ifdef ZENFS_EXPORT_PROMETHEUS
+                s = NewZenFS(&fs, zenFileSystems[devID],
+                             std::make_shared<ZenFSPrometheusMetrics>());
+#else
                 s = NewZenFS(&fs, zenFileSystems[devID]);
+#endif
                 if (!s.ok()) {
                   *errmsg = s.ToString();
                 }

--- a/fs/metrics_prometheus.cc
+++ b/fs/metrics_prometheus.cc
@@ -1,0 +1,108 @@
+#include "metrics_prometheus.h"
+
+#include <prometheus/collectable.h>
+#include <prometheus/counter.h>
+#include <prometheus/registry.h>
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+using namespace ROCKSDB_NAMESPACE;
+using namespace prometheus;
+
+ZenFSPrometheusMetrics::ZenFSPrometheusMetrics() {
+  registry_ = std::make_shared<Registry>();
+
+  for (auto &label_with_type : info_map_)
+    AddReporter(static_cast<uint32_t>(label_with_type.first),
+                static_cast<uint32_t>(label_with_type.second.second));
+
+  stop_collect_thread_.store(false);
+  collect_thread_ = new std::thread(&ZenFSPrometheusMetrics::run, this);
+}
+
+ZenFSPrometheusMetrics::~ZenFSPrometheusMetrics() {
+  stop_collect_thread_.store(true);
+  collect_thread_->join();
+}
+
+void ZenFSPrometheusMetrics::run() {
+  Exposer server{"127.0.0.1:8080"};
+  server.RegisterCollectable(registry_);
+
+  auto wake = std::chrono::steady_clock::now() +
+              std::chrono::milliseconds(this->report_interval_ms_);
+  while (!stop_collect_thread_.load()) {
+    std::this_thread::sleep_until(wake);
+    wake = wake + std::chrono::milliseconds(this->report_interval_ms_);
+    for (auto &metric : metric_map_) {
+      auto gm = metric.second;
+
+      // Handle concurrency by atomic exchange. We don't care about inaccuracy
+      // caused by counters not being swapped atomically all at once.
+      gm->gcount->Set(metric.second->count.exchange(0));
+      gm->gtotal->Set(metric.second->value.exchange(0));
+      gm->gmin->Set(metric.second->min.exchange(UINT64_MAX));
+      gm->gmax->Set(metric.second->max.exchange(0));
+    }
+  }
+}
+
+void ZenFSPrometheusMetrics::Report(uint32_t label_uint, size_t value,
+                                    uint32_t type_uint) {
+  auto label = static_cast<ZenFSMetricsHistograms>(label_uint);
+
+  if (metric_map_.find(label) == metric_map_.end()) return;
+
+  auto metric = metric_map_.find(label)->second;
+  metric->value += value;
+  metric->count++;
+
+  auto max = metric->max.load();
+  while (1) {
+    if (value > max) {
+      if (metric->max.compare_exchange_weak(max, value)) {
+        break;
+      }
+    } else {
+      break;
+    }
+  }
+
+  auto min = metric->min.load();
+  while (1) {
+    if (value < min) {
+      if (metric->min.compare_exchange_weak(min, value)) {
+        break;
+      }
+    } else {
+      break;
+    }
+  }
+}
+
+void ZenFSPrometheusMetrics::AddReporter(uint32_t label_uint,
+                                         ReporterType type) {
+  auto label = static_cast<ZenFSMetricsHistograms>(label_uint);
+
+  assert(info_map_.find(label) != info_map_.end());
+  if (info_map_.find(label) == info_map_.end()) return;
+
+  auto pair = info_map_.find(label)->second;
+  auto name = pair.first;
+
+  auto metric = std::make_shared<GaugeMetric>();
+
+  metric->family = &BuildGauge().Name(name).Register(*registry_);
+
+  metric->gmax = &metric->family->Add({{"type", "max"}});
+  metric->gmin = &metric->family->Add({{"type", "min"}});
+  metric->gcount = &metric->family->Add({{"type", "count"}});
+  metric->gtotal = &metric->family->Add({{"type", "total"}});
+
+  metric->min = UINT64_MAX;
+
+  metric_map_.emplace(label, metric);
+}

--- a/fs/metrics_prometheus.h
+++ b/fs/metrics_prometheus.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <prometheus/counter.h>
+#include <prometheus/exposer.h>
+#include <prometheus/registry.h>
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <thread>
+
+#include "metrics.h"
+
+class ResettingGauge;
+
+namespace ROCKSDB_NAMESPACE {
+
+using namespace prometheus;
+
+class GaugeMetric {
+ public:
+  Family<Gauge> *family;
+  Gauge *gmin;
+  Gauge *gmax;
+  Gauge *gtotal;
+  Gauge *gcount;
+  std::atomic<uint64_t> value;
+  std::atomic<uint64_t> count;
+  std::atomic<uint64_t> max;
+  std::atomic<uint64_t> min;
+};
+
+class ZenFSPrometheusMetrics : public rocksdb::ZenFSMetrics {
+ private:
+  std::shared_ptr<Registry> registry_;
+  std::unordered_map<ZenFSMetricsHistograms, std::shared_ptr<GaugeMetric>>
+      metric_map_;
+  uint64_t report_interval_ms_ = 5000;
+  std::thread *collect_thread_;
+  std::atomic_bool stop_collect_thread_;
+
+  const std::unordered_map<uint32_t, std::pair<std::string, uint32_t>>
+      info_map_ = {
+          {ZENFS_NON_WAL_WRITE_LATENCY,
+           {"zenfs_non_wal_write_latency", ZENFS_REPORTER_TYPE_LATENCY}},
+          {ZENFS_WAL_WRITE_LATENCY,
+           {"zenfs_wal_write_latency", ZENFS_REPORTER_TYPE_LATENCY}},
+          {ZENFS_READ_LATENCY,
+           {"zenfs_read_latency", ZENFS_REPORTER_TYPE_LATENCY}},
+          {ZENFS_WAL_SYNC_LATENCY,
+           {"zenfs_wal_sync_latency", ZENFS_REPORTER_TYPE_LATENCY}},
+          {ZENFS_NON_WAL_SYNC_LATENCY,
+           {"zenfs_non_wal_sync_latency", ZENFS_REPORTER_TYPE_LATENCY}},
+          {ZENFS_ZONE_WRITE_LATENCY,
+           {"zenfs_zone_write_latency", ZENFS_REPORTER_TYPE_LATENCY}},
+          {ZENFS_ROLL_LATENCY,
+           {"zenfs_roll_latency", ZENFS_REPORTER_TYPE_LATENCY}},
+          {ZENFS_META_ALLOC_LATENCY,
+           {"zenfs_meta_alloc_latency", ZENFS_REPORTER_TYPE_LATENCY}},
+          {ZENFS_META_SYNC_LATENCY,
+           {"zenfs_meta_sync_latency", ZENFS_REPORTER_TYPE_LATENCY}},
+          {ZENFS_WRITE_QPS, {"zenfs_write_qps", ZENFS_REPORTER_TYPE_QPS}},
+          {ZENFS_READ_QPS, {"zenfs_read_qps", ZENFS_REPORTER_TYPE_QPS}},
+          {ZENFS_SYNC_QPS, {"zenfs_sync_qps", ZENFS_REPORTER_TYPE_QPS}},
+          {ZENFS_META_ALLOC_QPS,
+           {"zenfs_meta_alloc_qps", ZENFS_REPORTER_TYPE_QPS}},
+          {ZENFS_IO_ALLOC_QPS, {"zenfs_io_alloc_qps", ZENFS_REPORTER_TYPE_QPS}},
+          {ZENFS_ROLL_QPS, {"zenfs_roll_qps", ZENFS_REPORTER_TYPE_QPS}},
+          {ZENFS_WRITE_THROUGHPUT,
+           {"zenfs_write_throughput", ZENFS_REPORTER_TYPE_THROUGHPUT}},
+          {ZENFS_RESETABLE_ZONES_COUNT,
+           {"zenfs_resetable_zones", ZENFS_REPORTER_TYPE_GENERAL}},
+          {ZENFS_OPEN_ZONES_COUNT,
+           {"zenfs_open_zones", ZENFS_REPORTER_TYPE_GENERAL}},
+          {ZENFS_ACTIVE_ZONES_COUNT,
+           {"zenfs_active_zones", ZENFS_REPORTER_TYPE_GENERAL}},
+      };
+
+  void run();
+
+ public:
+  ZenFSPrometheusMetrics();
+  ~ZenFSPrometheusMetrics();
+
+ private:
+  virtual void AddReporter(uint32_t label, ReporterType type = 0) override;
+  virtual void Report(uint32_t label_uint, size_t value,
+                      uint32_t type_uint = 0) override;
+
+ public:
+  virtual void ReportQPS(uint32_t label, size_t qps) override {
+    Report(label, qps, ZENFS_REPORTER_TYPE_QPS);
+  }
+  virtual void ReportLatency(uint32_t label, size_t latency) override {
+    Report(label, latency, ZENFS_REPORTER_TYPE_LATENCY);
+  }
+  virtual void ReportThroughput(uint32_t label, size_t throughput) override {
+    Report(label, throughput, ZENFS_REPORTER_TYPE_THROUGHPUT);
+  }
+  virtual void ReportGeneral(uint32_t label, size_t value) override {
+    Report(label, value, ZENFS_REPORTER_TYPE_GENERAL);
+  }
+
+  virtual void ReportSnapshot(const ZenFSSnapshot &snapshot) override {}
+};
+
+}  // namespace ROCKSDB_NAMESPACE

--- a/zenfs.mk
+++ b/zenfs.mk
@@ -1,6 +1,30 @@
-zenfs_SOURCES = fs/fs_zenfs.cc fs/zbd_zenfs.cc fs/io_zenfs.cc
-zenfs_HEADERS = fs/fs_zenfs.h fs/zbd_zenfs.h fs/io_zenfs.h fs/version.h fs/metrics.h fs/snapshot.h fs/filesystem_utility.h
-zenfs_LDFLAGS = -u zenfs_filesystem_reg
+
+zenfs_SOURCES-y = \
+	fs/fs_zenfs.cc \
+	fs/zbd_zenfs.cc \
+	fs/io_zenfs.cc
+
+zenfs_HEADERS-y = \
+	fs/fs_zenfs.h \
+	fs/zbd_zenfs.h \
+	fs/io_zenfs.h \
+	fs/version.h \
+	fs/metrics.h \
+	fs/snapshot.h \
+	fs/filesystem_utility.h
+
+zenfs_PKGCONFIG_REQUIRES-y += "libzbd >= 1.5.0"
+
+ZENFS_EXPORT_PROMETHEUS ?= n
+zenfs_HEADERS-$(ZENFS_EXPORT_PROMETHEUS) += fs/metrics_prometheus.h
+zenfs_SOURCES-$(ZENFS_EXPORT_PROMETHEUS) += fs/metrics_prometheus.cc
+zenfs_CXXFLAGS-$(ZENFS_EXPORT_PROMETHEUS) += -DZENFS_EXPORT_PROMETHEUS=1
+zenfs_PKGCONFIG_REQUIRES-$(ZENFS_EXPORT_PROMETHEUS) += ", prometheus-cpp-pull == 1.1.0"
+
+zenfs_SOURCES += $(zenfs_SOURCES-y)
+zenfs_HEADERS += $(zenfs_HEADERS-y)
+zenfs_CXXFLAGS += $(zenfs_CXXFLAGS-y)
+zenfs_LDFLAGS += -u zenfs_filesystem_reg
 
 ZENFS_ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
@@ -9,4 +33,4 @@ ifneq ($(.SHELLSTATUS),0)
 $(error Generating ZenFS version failed)
 endif
 
-zenfs_PKGCONFIG_REQUIRES = "libzbd >= 1.5.0"
+zenfs_PKGCONFIG_REQUIRES = $(zenfs_PKGCONFIG_REQUIRES-y)


### PR DESCRIPTION
Set environment variable ZENFS_EXPORT_PROMETHEUS=y when building to enable
prometheus export of metrics. Exporter will listen on 127.0.0.1:8080.

Requires prometheus-cpp-pull == 1.1.0.
