### PR TITLE
db_stress verification

### DIFF
--- a/fs/filesystem_utility.h
+++ b/fs/filesystem_utility.h
@@ -65,8 +65,8 @@ class path {
     assert(segs[0] != "..");
 
     // We have a filename only if we don't have a terminator
-    bool has_terminator = *(--src_path_.end()) == '/';
-    if (!has_terminator) {
+    has_terminator_ = *(--src_path_.end()) == '/';
+    if (!has_terminator_) {
       filename_ = *(--segs.end());
     }
 
@@ -83,10 +83,10 @@ class path {
       //
       // `/a/b/c   ->  /a/b/ `
       // `/a/b/c/` ->  /a/b/c/ `
-      if (!has_terminator && i == segs.size() - 2) {
+      if (!has_terminator_ && i == segs.size() - 2) {
         parent_path_ = rst.str() + "/";
       }
-      if (!has_terminator && i == segs.size() - 1) {
+      if (!has_terminator_ && i == segs.size() - 1) {
         break;
       }
       rst << "/";
@@ -95,7 +95,7 @@ class path {
     normalized_path_ = rst.str();
     // If current source path is a directory, the parent path reminds the
     // same (@see std::filesystem::path::parent_path())
-    if (has_terminator) {
+    if (has_terminator_) {
       parent_path_ = normalized_path_;
     }
     return *this;
@@ -117,5 +117,6 @@ class path {
   std::string parent_path_;
   // @see std::filesystem::path::filename()
   std::string filename_;
+  bool has_terminator_ = false;
 };
 }  // namespace filesystem_utility

--- a/fs/filesystem_utility.h
+++ b/fs/filesystem_utility.h
@@ -39,6 +39,7 @@ class path {
 
     if (src_path_.compare("/") == 0) {
       normalized_path_ = src_path_;
+      has_terminator_ = true;
       return *this;
     }
 
@@ -108,7 +109,11 @@ class path {
   bool has_filename() { return !filename_.empty(); }
 
   path operator/(const path& other) const {
-    return path(normalized_path_ + other.string());
+    std::string seperator = "/";
+    if (has_terminator_) {
+      seperator = "";
+    }
+    return path(normalized_path_ + seperator + other.string());
   }
 
  private:


### PR DESCRIPTION
This PR fixes a verification error that occurred when executing db_stress (RocksDB v6.29.5):

```
./db_stress --ops_per_thread=1000 --reopen=5 --db=dbname --fs-uri=zenfs://dev:nvmeXnX --read_fault_one_in=0
```

<del>When boost::filesystem is enabled instead of filesystem_utility.h the "fs: Do not prepend path with '/' in `FormatPathLexically`" commit is necessary otherwise executing db_stress will end in the following error:
`open error: IO error: RenameLink: Failed to find the linked file`</del>

<del>If filesystem_utility.h is enabled the "fs: Do not prepend path with '/' in `FormatPathLexically`" commit is not strictly necessary.</del>