### PR TITLE
build: make zenfs work with cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.4)
+
+set(zenfs_SOURCES "fs/fs_zenfs.cc" "fs/zbd_zenfs.cc" "fs/io_zenfs.cc" PARENT_SCOPE)
+set(zenfs_HEADERS "fs/fs_zenfs.h" "fs/zbd_zenfs.h" "fs/io_zenfs.h" "fs/version.h" "fs/metrics.h"
+    "fs/snapshot.h" "fs/filesystem_utility.h" PARENT_SCOPE)
+set(zenfs_LIBS "zbd" PARENT_SCOPE)
+set(zenfs_CMAKE_EXE_LINKER_FLAGS "-u zenfs_filesystems_reg" PARENT_SCOPE)
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(ZBD REQUIRED libzbd>=1.5.0)
+
+execute_process(WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                RESULT_VARIABLE GENVER_RESULT
+                COMMAND ./generate-version.sh)
+if(GENVER_RESULT AND NOT GENVER_RESULT EQUAL 0)
+  message(FATAL_ERROR "Generating ZenFS version failed")
+endif()


### PR DESCRIPTION
rocksdb has a guideline for how to integrate with the cmake
build system. Simply provide plugin specific variables with
.cc files and the library requirements.

We run generate_version.sh at cmake time - this should be
ok since any change in the git repo could affect cmake,
and as such cmake should be rerun anyways. Also, with
the current cmake infrastructure in rocksdb, it doesn't
seem to be possible to run generate_version.sh at build
time prior to processing the zenfs source files.

Signed-off-by: Jorgen Hansen <jorgen.hansen@wdc.com>