### PR TITLE
fs: make zenfs compile with c++11 again

### DIFF
--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -175,10 +175,10 @@ ZonedBlockDevice::ZonedBlockDevice(std::string path, ZbdBackendType backend,
                                    std::shared_ptr<ZenFSMetrics> metrics)
     : logger_(logger), metrics_(metrics) {
   if (backend == ZbdBackendType::kBlockDev) {
-    zbd_be_ = std::make_unique<ZbdlibBackend>(path);
+    zbd_be_ = std::unique_ptr<ZbdlibBackend>(new ZbdlibBackend(path));
     Info(logger_, "New Zoned Block Device: %s", zbd_be_->GetFilename().c_str());
   } else if (backend == ZbdBackendType::kZoneFS) {
-    zbd_be_ = std::make_unique<ZoneFsBackend>(path);
+    zbd_be_ = std::unique_ptr<ZoneFsBackend>(new ZoneFsBackend(path));
     Info(logger_, "New zonefs backing: %s", zbd_be_->GetFilename().c_str());
   }
 }

--- a/fs/zonefs_zenfs.h
+++ b/fs/zonefs_zenfs.h
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <unistd.h>
 
+#include <list>
 #include <map>
 #include <string>
 


### PR DESCRIPTION
Fix the broken c++11 builds by open-coding make_unique (c++14)
and include the <list> header.

Signed-off-by: Hans Holmberg <hans.holmberg@wdc.com>