### PR TITLE
fs: Provide shim for NewZenFS calls that don't know about zonefs

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1514,6 +1514,11 @@ static std::string GetLogFilename(std::string bdev) {
 }
 #endif
 
+Status NewZenFS(FileSystem** fs, const std::string& bdevname,
+                std::shared_ptr<ZenFSMetrics> metrics) {
+  return NewZenFS(fs, ZbdBackendType::kBlockDev, bdevname, metrics);
+}
+
 Status NewZenFS(FileSystem** fs, const ZbdBackendType backend_type,
                 const std::string& backend_name,
                 std::shared_ptr<ZenFSMetrics> metrics) {

--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -451,6 +451,9 @@ class ZenFS : public FileSystemWrapper {
 #endif  // !defined(ROCKSDB_LITE) && defined(OS_LINUX)
 
 Status NewZenFS(
+    FileSystem** fs, const std::string& bdevname,
+    std::shared_ptr<ZenFSMetrics> metrics = std::make_shared<NoZenFSMetrics>());
+Status NewZenFS(
     FileSystem** fs, const ZbdBackendType backend_type,
     const std::string& backend_name,
     std::shared_ptr<ZenFSMetrics> metrics = std::make_shared<NoZenFSMetrics>());


### PR DESCRIPTION
External callers of NewZenFS may not be aware of the zonefs support, so make a shim that converts from the "old" signature to the new one.

Signed-off-by: Jorgen Hansen <jorgen.hansen@wdc.com>