### PR TITLE
cmake: Make it possible to skip libzbd check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,10 @@ set(zenfs_HEADERS "fs/fs_zenfs.h" "fs/zbd_zenfs.h" "fs/io_zenfs.h" "fs/version.h
 set(zenfs_LIBS "zbd" PARENT_SCOPE)
 set(zenfs_CMAKE_EXE_LINKER_FLAGS "-u zenfs_filesystems_reg" PARENT_SCOPE)
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(ZBD REQUIRED libzbd>=1.5.0)
+if(NOT ZENFS_SKIP_LIBZBD_CHECK)
+  find_package(PkgConfig REQUIRED)
+  pkg_check_modules(ZBD REQUIRED libzbd>=1.5.0)
+endif()
 
 execute_process(WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                 RESULT_VARIABLE GENVER_RESULT


### PR DESCRIPTION
Introduce an environment variable check that makes it possible to skip the libzbd check in cases where libzbd isn't provided througha package.

Signed-off-by: Jorgen Hansen <jorgen.hansen@wdc.com>