### PR TITLE
util: Fix AddDirSeparatorAtEnd where back() can not be called on an e…

### DIFF
--- a/.github/workflows/cpp-lint.yaml
+++ b/.github/workflows/cpp-lint.yaml
@@ -4,7 +4,7 @@ on:
     - master
   pull_request:
     branches:
-    - master
+    - '**'
 name: Lint
 jobs:
   clang-format:

--- a/.github/workflows/smoke-test-debug.yaml
+++ b/.github/workflows/smoke-test-debug.yaml
@@ -4,7 +4,7 @@ on:
     - master
   pull_request:
     branches:
-    - master
+    - '**'
 name: Quick Test (Debug)
 jobs:
   smoke-test-debug:

--- a/.github/workflows/smoke-test.yaml
+++ b/.github/workflows/smoke-test.yaml
@@ -4,7 +4,7 @@ on:
     - master
   pull_request:
     branches:
-    - master
+    - '**'
 name: Quick Test
 jobs:
   smoke-test:

--- a/util/zenfs.cc
+++ b/util/zenfs.cc
@@ -50,7 +50,7 @@ DEFINE_string(dest_file, "", "Destination file path");
 namespace ROCKSDB_NAMESPACE {
 
 void AddDirSeparatorAtEnd(std::string &path) {
-  if (path.back() != '/') path = path + "/";
+  if (path.empty() || path.back() != '/') path = path + "/";
 }
 
 std::unique_ptr<ZonedBlockDevice> zbd_open(bool readonly, bool exclusive) {


### PR DESCRIPTION
…mpty string

Fixes this issue: https://github.com/westerndigitalcorporation/zenfs/issues/227

Suggested-by: Yura Sorokin <yura.sorokin@percona.com>
Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>