### PR TITLE
zenfs: Do not Repair() when the mount is read-only mode.

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1396,8 +1396,10 @@ Status ZenFS::Mount(bool readonly) {
     }
   }
 
-  s = Repair();
-  if (!s.ok()) return s;
+  if (!readonly) {
+    s = Repair();
+    if (!s.ok()) return s;
+  }
 
   if (readonly) {
     Info(logger_, "Mounting READ ONLY");

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -628,7 +628,7 @@ IOStatus ZoneFile::RecoverSparseExtents(uint64_t start, uint64_t end,
 
     extent_length = DecodeFixed64(buffer);
     if (extent_length == 0) {
-      s = IOStatus::IOError("Unexexpeted extent length while recovering");
+      s = IOStatus::IOError("Unexpected extent length while recovering");
       break;
     }
     recovered_segments++;


### PR DESCRIPTION
Observed that when heavy workloads are running(like sysbench) on zenfs, commands like "zenfs df/list" would error out with below error log. "Unexexpeted extent length while recovering".

When mounted in read-only mode, the process mounting it is understood to not make any changes to the filesystem. So it is better to do a repair() when the process has the intent to write data/metadata (write mode mount). Also when mounted in read-only mode(by say zenfs list), there could be write happening by RocksDB which can alter the data/metadata state and doing a repair at that time in a read-only mount state is also not warranted.

So do repair when mounted with write permission.

Signed-off-by: Aravind Ramesh <aravind.ramesh@wdc.com>