### PR TITLE
Fix Segmentation fault while enable zenfs gc.

### DIFF
--- a/fs/zbd_zenfs.cc
+++ b/fs/zbd_zenfs.cc
@@ -356,8 +356,14 @@ void ZonedBlockDevice::LogGarbageInfo() {
       continue;
     }
 
-    double garbage_rate =
-        double(z->wp_ - z->start_ - z->used_capacity_) / z->max_capacity_;
+    double garbage_rate = 0;
+    if (z->IsFull()) {
+      garbage_rate =
+          double(z->max_capacity_ - z->used_capacity_) / z->max_capacity_;
+    } else {
+      garbage_rate =
+          double(z->wp_ - z->start_ - z->used_capacity_) / z->max_capacity_;
+    }
     assert(garbage_rate > 0);
     int idx = int((garbage_rate + 0.1) * 10);
     zone_gc_stat[idx]++;


### PR DESCRIPTION
When zone become full, the `wp_` will be negative value, so change to use `max_capacity_`.