### PR TITLE
fs: fixed clang-16 compilation warnings

### DIFF
--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -25,7 +25,7 @@ namespace ROCKSDB_NAMESPACE {
 class ZoneSnapshot;
 class ZoneFileSnapshot;
 class ZenFSSnapshot;
-class ZenFSSnapshotOptions;
+struct ZenFSSnapshotOptions;
 
 class Superblock {
   uint32_t magic_ = 0;

--- a/fs/io_zenfs.cc
+++ b/fs/io_zenfs.cc
@@ -617,7 +617,6 @@ IOStatus ZoneFile::RecoverSparseExtents(uint64_t start, uint64_t end,
   int f = zbd_->GetReadFD();
   uint64_t next_extent_start = start;
   char* buffer;
-  int recovered_segments = 0;
   int ret;
 
   ret = posix_memalign((void**)&buffer, sysconf(_SC_PAGESIZE), block_sz);
@@ -639,7 +638,6 @@ IOStatus ZoneFile::RecoverSparseExtents(uint64_t start, uint64_t end,
       s = IOStatus::IOError("Unexexpeted extent length while recovering");
       break;
     }
-    recovered_segments++;
 
     zone->used_capacity_ += extent_length;
     extents_.push_back(new ZoneExtent(next_extent_start + SPARSE_HEADER_SIZE,

--- a/fs/metrics.h
+++ b/fs/metrics.h
@@ -36,7 +36,7 @@ namespace ROCKSDB_NAMESPACE {
 
 class ZenFSMetricsGuard;
 class ZenFSSnapshot;
-class ZenFSSnapshotOptions;
+struct ZenFSSnapshotOptions;
 
 // Types of Reporter that may be used for statistics.
 enum ZenFSMetricsReporterType : uint32_t {

--- a/fs/snapshot.h
+++ b/fs/snapshot.h
@@ -35,7 +35,6 @@ class ZBDSnapshot {
 
  public:
   ZBDSnapshot() = default;
-  ZBDSnapshot(const ZBDSnapshot&) = default;
   ZBDSnapshot(ZonedBlockDevice& zbd)
       : free_space(zbd.GetFreeSpace()),
         used_space(zbd.GetUsedSpace()),

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -33,7 +33,7 @@ namespace ROCKSDB_NAMESPACE {
 
 class ZonedBlockDevice;
 class ZoneSnapshot;
-class ZenFSSnapshotOptions;
+struct ZenFSSnapshotOptions;
 
 class Zone {
   ZonedBlockDevice *zbd_;


### PR DESCRIPTION
* Fixed mismatching 'class' / 'struct' declarations.
* Removed '=default' copy constructor declaration for the 'ZBDSnapshot' as it violates the "rule of 5".
* Eliminated dead code in 'ZoneFile::RecoverSparseExtents()'.