### PR TITLE
fs: fixed gcc-13 compilation warnings

### DIFF
--- a/fs/fs_zenfs.cc
+++ b/fs/fs_zenfs.cc
@@ -1477,7 +1477,7 @@ Status ZenFS::MkFS(std::string aux_fs_p, uint32_t finish_threshold) {
   super.EncodeTo(&super_string);
 
   s = log->AddRecord(super_string);
-  if (!s.ok()) return std::move(s);
+  if (!s.ok()) return static_cast<Status>(s);
 
   /* Write an empty snapshot to make the metadata zone valid */
   s = PersistSnapshot(log.get());


### PR DESCRIPTION
Fix the following issue using the same approach as fixes in RocksDB:

```
/data/mysql-server/percona-8.0/storage/rocksdb/rocksdb_plugins/zenfs/fs/fs_zenfs.cc: In member function ‘rocksdb::Status rocksdb::ZenFS::MkFS(std::string, uint32_t)’:
/data/mysql-server/percona-8.0/storage/rocksdb/rocksdb_plugins/zenfs/fs/fs_zenfs.cc:1480:32: error: redundant move in return statement [-Werror=redundant-move]
 1480 |   if (!s.ok()) return std::move(s);
      |                       ~~~~~~~~~^~~
/data/mysql-server/percona-8.0/storage/rocksdb/rocksdb_plugins/zenfs/fs/fs_zenfs.cc:1480:32: note: remove ‘std::move’ call
```

Signed-off-by: Przemyslaw Skibinski <przemyslaw.skibinski@percona.com>