### PR TITLE
ci: Overwrite cron schedules on workflows

### DIFF
--- a/.github/workflows/long-performance.yaml
+++ b/.github/workflows/long-performance.yaml
@@ -2,7 +2,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 21 * * sun'
+    - cron: '0 22 * * sun'
 name: Long Performance Test
 jobs:
   long-performance:

--- a/.github/workflows/mtr-test.yaml
+++ b/.github/workflows/mtr-test.yaml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 21 * * fri'
+    - cron: '0 22 * * fri'
 name: MTR Tests
 jobs:
   mtr-tests:

--- a/.github/workflows/percona-server-smoke-test.yaml
+++ b/.github/workflows/percona-server-smoke-test.yaml
@@ -7,7 +7,7 @@ on:
     branches:
     - '[0-9]+.[0-9]+'
   schedule:
-    - cron: '0 23 * * *'
+    - cron: '0 0 * * *'
 name: Percona Server Smoke Test
 jobs:
   smoke-test:

--- a/.github/workflows/rocks-nightly.yaml
+++ b/.github/workflows/rocks-nightly.yaml
@@ -1,7 +1,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 01 * * *'
+    - cron: '0 02 * * *'
 name: Smoke RocksDB Nightly
 jobs:
   smoke-nightly:

--- a/.github/workflows/short-performance.yaml
+++ b/.github/workflows/short-performance.yaml
@@ -2,7 +2,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 21 * * *'
+    - cron: '0 22 * * *'
 name: Short Performance Test
 jobs:
   quick-performance:

--- a/.github/workflows/zbdbench.yaml
+++ b/.github/workflows/zbdbench.yaml
@@ -2,7 +2,7 @@
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 21 * * sat'
+    - cron: '0 22 * * sat'
 name: ZBDBench
 jobs:
   zbdbench:


### PR DESCRIPTION
Overwriting cron schedules, such that Andreas Hindborg (https://github.com/metaspace) does not get notifications triggered by scheduled workflows that fail.