### PR TITLE
fs: fix compile error on latest RocksDB

### DIFF
--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -334,6 +334,7 @@ class ZenFS : public FileSystemWrapper {
 
   IOStatus GetFileSize(const std::string& f, const IOOptions& options,
                        uint64_t* size, IODebugContext* dbg) override;
+
   IOStatus RenameFile(const std::string& f, const std::string& t,
                       const IOOptions& options, IODebugContext* dbg) override;
 

--- a/fs/io_zenfs.h
+++ b/fs/io_zenfs.h
@@ -226,6 +226,11 @@ class ZonedWritableFile : public FSWritableFile {
   virtual IOStatus Fsync(const IOOptions& options,
                          IODebugContext* dbg) override;
 
+  virtual uint64_t GetFileSize(const IOOptions& /*options*/,
+                               IODebugContext* /*dbg*/) override {
+    return zoneFile_->GetFileSize();
+  }
+
   bool use_direct_io() const override { return !buffered; }
   bool IsSyncThreadSafe() const override { return true; };
   size_t GetRequiredBufferAlignment() const override {


### PR DESCRIPTION
WritableFile::GetFileSize needs to be imlemented now, so hook it up to make it compilable on latest rocksdb.